### PR TITLE
feat: extend property domain models

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ npm run seed         # migrate + seed demo data
 
 ## API overview
 
-All routes are prefixed with `/v1`. Mutation endpoints require JWT Bearer authentication (`Authorization: Bearer <token>`), and additional role checks (`ADMIN`, `EDITOR`, `VIEWER`).
+All routes are prefixed with `/v1`. Mutation endpoints require JWT Bearer authentication (`Authorization: Bearer <token>`), and additional role checks (`ADMIN`, `EDITOR`, `AGENT`, `USER`).
 
 - `POST /v1/auth/login` – Obtain access token
 - `GET /v1/auth/me` – Current user profile

--- a/prisma/migrations/20241009120000_property_enhancements/migration.sql
+++ b/prisma/migrations/20241009120000_property_enhancements/migration.sql
@@ -1,0 +1,238 @@
+-- CreateTable
+CREATE TABLE `User` (
+    `id` VARCHAR(191) NOT NULL,
+    `username` VARCHAR(191) NOT NULL,
+    `passwordHash` VARCHAR(191) NOT NULL,
+    `role` ENUM('ADMIN', 'EDITOR', 'AGENT', 'USER') NOT NULL DEFAULT 'ADMIN',
+    `localePref` VARCHAR(191) NOT NULL DEFAULT 'en',
+    `isActive` BOOLEAN NOT NULL DEFAULT true,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `User_username_key`(`username`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Property` (
+    `id` VARCHAR(191) NOT NULL,
+    `slug` VARCHAR(191) NOT NULL,
+    `status` ENUM('AVAILABLE', 'RESERVED', 'SOLD') NOT NULL DEFAULT 'AVAILABLE',
+    `type` ENUM('CONDO', 'HOUSE', 'LAND', 'COMMERCIAL') NOT NULL,
+    `price` INTEGER NOT NULL,
+    `area` DOUBLE NULL,
+    `beds` INTEGER NULL,
+    `baths` INTEGER NULL,
+    `locationId` VARCHAR(191) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+    `reservedUntil` DATETIME(3) NULL,
+    `deposit` BOOLEAN NOT NULL DEFAULT false,
+    `isHidden` BOOLEAN NOT NULL DEFAULT false,
+    `deletedAt` DATETIME(3) NULL,
+
+    UNIQUE INDEX `Property_slug_key`(`slug`),
+    INDEX `Property_status_type_price_idx`(`status`, `type`, `price`),
+    INDEX `Property_status_type_updatedAt_idx`(`status`, `type`, `updatedAt`),
+    INDEX `Property_locationId_idx`(`locationId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `PropertyImage` (
+    `id` VARCHAR(191) NOT NULL,
+    `propertyId` VARCHAR(191) NOT NULL,
+    `url` VARCHAR(191) NOT NULL,
+    `order` INTEGER NOT NULL DEFAULT 0,
+
+    UNIQUE INDEX `PropertyImage_propertyId_order_key`(`propertyId`, `order`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `PropertyI18N` (
+    `id` VARCHAR(191) NOT NULL,
+    `propertyId` VARCHAR(191) NOT NULL,
+    `locale` VARCHAR(191) NOT NULL,
+    `title` VARCHAR(191) NOT NULL,
+    `description` VARCHAR(191) NULL,
+    `amenities` JSON NULL,
+
+    UNIQUE INDEX `PropertyI18N_propertyId_locale_key`(`propertyId`, `locale`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Article` (
+    `id` VARCHAR(191) NOT NULL,
+    `slug` VARCHAR(191) NOT NULL,
+    `published` BOOLEAN NOT NULL DEFAULT false,
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `Article_slug_key`(`slug`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `ArticleI18N` (
+    `id` VARCHAR(191) NOT NULL,
+    `articleId` VARCHAR(191) NOT NULL,
+    `locale` VARCHAR(191) NOT NULL,
+    `title` VARCHAR(191) NOT NULL,
+    `body` JSON NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `ChangeSet` (
+    `id` VARCHAR(191) NOT NULL,
+    `entityType` VARCHAR(191) NOT NULL,
+    `entityId` VARCHAR(191) NULL,
+    `patch` JSON NOT NULL,
+    `status` VARCHAR(191) NOT NULL,
+    `scheduleAt` DATETIME(3) NULL,
+    `createdBy` VARCHAR(191) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `PublishJob` (
+    `id` VARCHAR(191) NOT NULL,
+    `changesetId` VARCHAR(191) NOT NULL,
+    `runAt` DATETIME(3) NOT NULL,
+    `status` VARCHAR(191) NOT NULL,
+    `log` VARCHAR(191) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `AuditLog` (
+    `id` VARCHAR(191) NOT NULL,
+    `userId` VARCHAR(191) NOT NULL,
+    `action` VARCHAR(191) NOT NULL,
+    `entityType` VARCHAR(191) NOT NULL,
+    `entityId` VARCHAR(191) NULL,
+    `meta` JSON NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Rate` (
+    `code` VARCHAR(191) NOT NULL,
+    `value` DOUBLE NOT NULL,
+    `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`code`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Location` (
+    `id` VARCHAR(191) NOT NULL,
+    `province` VARCHAR(191) NOT NULL,
+    `district` VARCHAR(191) NULL,
+    `subdistrict` VARCHAR(191) NULL,
+    `lat` DOUBLE NULL,
+    `lng` DOUBLE NULL,
+
+    INDEX `Location_province_idx`(`province`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `PropertyFlagOnProperty` (
+    `propertyId` VARCHAR(191) NOT NULL,
+    `flag` ENUM('FEATURED', 'HIGHLIGHTED', 'URGENT') NOT NULL,
+    `assignedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`propertyId`, `flag`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Favorite` (
+    `id` VARCHAR(191) NOT NULL,
+    `userId` VARCHAR(191) NOT NULL,
+    `propertyId` VARCHAR(191) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `Favorite_userId_propertyId_key`(`userId`, `propertyId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `ViewStat` (
+    `id` VARCHAR(191) NOT NULL,
+    `propertyId` VARCHAR(191) NOT NULL,
+    `bucket` DATETIME(3) NOT NULL,
+    `views` INTEGER NOT NULL DEFAULT 0,
+
+    UNIQUE INDEX `ViewStat_propertyId_bucket_key`(`propertyId`, `bucket`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `TransitStation` (
+    `id` VARCHAR(191) NOT NULL,
+    `name` VARCHAR(191) NOT NULL,
+    `type` VARCHAR(191) NOT NULL,
+    `lat` DOUBLE NULL,
+    `lng` DOUBLE NULL,
+
+    INDEX `TransitStation_type_name_idx`(`type`, `name`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `PropertyTransitStation` (
+    `propertyId` VARCHAR(191) NOT NULL,
+    `stationId` VARCHAR(191) NOT NULL,
+    `distance` INTEGER NULL,
+
+    PRIMARY KEY (`propertyId`, `stationId`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Property` ADD CONSTRAINT `Property_locationId_fkey` FOREIGN KEY (`locationId`) REFERENCES `Location`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `PropertyImage` ADD CONSTRAINT `PropertyImage_propertyId_fkey` FOREIGN KEY (`propertyId`) REFERENCES `Property`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `PropertyI18N` ADD CONSTRAINT `PropertyI18N_propertyId_fkey` FOREIGN KEY (`propertyId`) REFERENCES `Property`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ArticleI18N` ADD CONSTRAINT `ArticleI18N_articleId_fkey` FOREIGN KEY (`articleId`) REFERENCES `Article`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ChangeSet` ADD CONSTRAINT `ChangeSet_createdBy_fkey` FOREIGN KEY (`createdBy`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `PublishJob` ADD CONSTRAINT `PublishJob_changesetId_fkey` FOREIGN KEY (`changesetId`) REFERENCES `ChangeSet`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `AuditLog` ADD CONSTRAINT `AuditLog_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `PropertyFlagOnProperty` ADD CONSTRAINT `PropertyFlagOnProperty_propertyId_fkey` FOREIGN KEY (`propertyId`) REFERENCES `Property`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Favorite` ADD CONSTRAINT `Favorite_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Favorite` ADD CONSTRAINT `Favorite_propertyId_fkey` FOREIGN KEY (`propertyId`) REFERENCES `Property`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ViewStat` ADD CONSTRAINT `ViewStat_propertyId_fkey` FOREIGN KEY (`propertyId`) REFERENCES `Property`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `PropertyTransitStation` ADD CONSTRAINT `PropertyTransitStation_propertyId_fkey` FOREIGN KEY (`propertyId`) REFERENCES `Property`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `PropertyTransitStation` ADD CONSTRAINT `PropertyTransitStation_stationId_fkey` FOREIGN KEY (`stationId`) REFERENCES `TransitStation`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,3 @@
+# Prisma Migrate lockfile
+# This file was created manually to track the current datasource provider.
+provider = "mysql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,14 @@ datasource db {
 enum Role {
   ADMIN
   EDITOR
-  VIEWER
+  AGENT
+  USER
+}
+
+enum PropertyFlag {
+  FEATURED
+  HIGHLIGHTED
+  URGENT
 }
 
 enum PropertyType {
@@ -27,33 +34,45 @@ enum PropertyStatus {
 }
 
 model User {
-  id           String   @id @default(cuid())
-  username     String   @unique
+  id           String    @id @default(cuid())
+  username     String    @unique
   passwordHash String
-  role         Role     @default(ADMIN)
-  isActive     Boolean  @default(true)
-  createdAt    DateTime @default(now())
+  role         Role      @default(ADMIN)
+  localePref   String    @default("en")
+  isActive     Boolean   @default(true)
+  createdAt    DateTime  @default(now())
   auditLogs    AuditLog[]
   changeSets   ChangeSet[] @relation("ChangeSetCreatedBy")
+  favorites    Favorite[]
 }
 
 model Property {
-  id            String          @id @default(cuid())
-  slug          String          @unique
-  status        PropertyStatus  @default(AVAILABLE)
-  type          PropertyType
-  price         Int
-  area          Float?
-  beds          Int?
-  baths         Int?
-  locationId    String?
-  location      Location?       @relation(fields: [locationId], references: [id])
-  createdAt     DateTime        @default(now())
-  updatedAt     DateTime        @updatedAt
-  images        PropertyImage[]
-  i18n          PropertyI18N[]
-  reservedUntil DateTime?
-  deposit       Boolean?        @default(false)
+  id              String                 @id @default(cuid())
+  slug            String                 @unique
+  status          PropertyStatus         @default(AVAILABLE)
+  type            PropertyType
+  price           Int
+  area            Float?
+  beds            Int?
+  baths           Int?
+  locationId      String?
+  location        Location?              @relation(fields: [locationId], references: [id])
+  createdAt       DateTime               @default(now())
+  updatedAt       DateTime               @updatedAt
+  reservedUntil   DateTime?
+  deposit         Boolean                @default(false)
+  isHidden        Boolean                @default(false)
+  deletedAt       DateTime?
+  images          PropertyImage[]
+  i18n            PropertyI18N[]
+  flags           PropertyFlagOnProperty[]
+  favorites       Favorite[]
+  viewStats       ViewStat[]
+  transitStations PropertyTransitStation[]
+
+  @@index([status, type, price])
+  @@index([status, type, updatedAt])
+  @@index([locationId])
 }
 
 model PropertyImage {
@@ -62,6 +81,8 @@ model PropertyImage {
   url        String
   order      Int      @default(0)
   property   Property @relation(fields: [propertyId], references: [id], onDelete: Cascade)
+
+  @@unique([propertyId, order])
 }
 
 model PropertyI18N {
@@ -72,6 +93,8 @@ model PropertyI18N {
   description String?
   amenities   Json?
   property    Property @relation(fields: [propertyId], references: [id], onDelete: Cascade)
+
+  @@unique([propertyId, locale])
 }
 
 model Article {
@@ -140,4 +163,57 @@ model Location {
   lat        Float?
   lng        Float?
   properties Property[]
+
+  @@index([province])
+}
+
+model PropertyFlagOnProperty {
+  propertyId String
+  flag       PropertyFlag
+  assignedAt DateTime  @default(now())
+  property   Property  @relation(fields: [propertyId], references: [id], onDelete: Cascade)
+
+  @@id([propertyId, flag])
+}
+
+model Favorite {
+  id         String   @id @default(cuid())
+  userId     String
+  propertyId String
+  createdAt  DateTime @default(now())
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  property   Property @relation(fields: [propertyId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, propertyId])
+}
+
+model ViewStat {
+  id         String   @id @default(cuid())
+  propertyId String
+  bucket     DateTime
+  views      Int      @default(0)
+  property   Property @relation(fields: [propertyId], references: [id], onDelete: Cascade)
+
+  @@unique([propertyId, bucket])
+}
+
+model TransitStation {
+  id          String                    @id @default(cuid())
+  name        String
+  type        String
+  lat         Float?
+  lng         Float?
+  properties  PropertyTransitStation[]
+
+  @@index([type, name])
+}
+
+model PropertyTransitStation {
+  propertyId String
+  stationId  String
+  distance   Int?
+  property   Property       @relation(fields: [propertyId], references: [id], onDelete: Cascade)
+  station    TransitStation  @relation(fields: [stationId], references: [id], onDelete: Cascade)
+
+  @@id([propertyId, stationId])
 }

--- a/src/prisma/types.ts
+++ b/src/prisma/types.ts
@@ -1,4 +1,6 @@
-export type Role = 'ADMIN' | 'EDITOR' | 'VIEWER';
+export type Role = 'ADMIN' | 'EDITOR' | 'AGENT' | 'USER';
+
+export type PropertyFlag = 'FEATURED' | 'HIGHLIGHTED' | 'URGENT';
 
 export type PropertyStatus = 'AVAILABLE' | 'RESERVED' | 'SOLD';
 export type PropertyType = 'CONDO' | 'HOUSE' | 'LAND' | 'COMMERCIAL';
@@ -39,12 +41,52 @@ export interface Property {
   baths: number | null;
   locationId: string | null;
   reservedUntil: Date | null;
-  deposit: boolean | null;
+  deposit: boolean;
+  isHidden: boolean;
+  deletedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
   images: PropertyImage[];
   i18n: PropertyI18N[];
+  flags: PropertyFlagOnProperty[];
+  favorites: Favorite[];
+  viewStats: ViewStat[];
+  transitStations: PropertyTransitStation[];
   location: Location | null;
+}
+
+export interface PropertyFlagOnProperty {
+  propertyId: string;
+  flag: PropertyFlag;
+  assignedAt: Date;
+}
+
+export interface Favorite {
+  id: string;
+  userId: string;
+  propertyId: string;
+  createdAt: Date;
+}
+
+export interface ViewStat {
+  id: string;
+  propertyId: string;
+  bucket: Date;
+  views: number;
+}
+
+export interface TransitStation {
+  id: string;
+  name: string;
+  type: string;
+  lat: number | null;
+  lng: number | null;
+}
+
+export interface PropertyTransitStation {
+  propertyId: string;
+  stationId: string;
+  distance: number | null;
 }
 
 export interface ArticleI18N {


### PR DESCRIPTION
## Summary
- expand the Prisma role enum and user profile with locale preferences and favorites
- extend property entities with lifecycle fields, indexing, flags, transit, favorites, and related supporting models
- add the initial additive migration and regenerate Prisma client types used in the codebase

## Testing
- `npm run build` *(fails: existing StringFilter mode typing errors in src/modules/suggest/service.ts)*
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68cbfb3979f8832ba7f00e0a6a2c640e