### PR TITLE
Refactor search indexing into localized shards

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ All routes are prefixed with `/v1`. Mutation endpoints require JWT Bearer authen
 - `GET /v1/schedule/jobs` – List publish jobs (ADMIN)
 - `POST /v1/index/rebuild` – Force index rebuild (ADMIN)
 - `POST /v1/backup` – Stream ZIP backup (ADMIN)
-- `GET /v1/suggest?q=` – Lightweight suggestion service
+- `GET /api/suggest?q=` – Lightweight suggestion service sourced from prebuilt data
 
 All mutating operations emit audit log entries.
 

--- a/src/modules/index/service.ts
+++ b/src/modules/index/service.ts
@@ -1,21 +1,80 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import MiniSearch from 'minisearch';
+import { PropertyType } from '@prisma/client';
 import { prisma } from '../../prisma/client';
 import { env } from '../../env';
 import { ensureDir } from '../../common/utils/file';
+
+type SupportedLocale = 'th' | 'en' | 'zh';
+
+interface PropertyDoc {
+  id: string;
+  entityId: string;
+  slug: string;
+  locale: SupportedLocale;
+  title: string;
+  description: string;
+  status: string;
+  type: PropertyType;
+  price: number;
+  province: string;
+  location: string;
+  deposit: boolean;
+}
+
+interface LocaleBucket {
+  docs: PropertyDoc[];
+  index: MiniSearch<PropertyDoc>;
+}
+
+interface ShardBucket {
+  province: string;
+  type: PropertyType;
+  fileName: string;
+  locales: Partial<Record<SupportedLocale, LocaleBucket>>;
+}
+
+interface ShardMetadata {
+  file: string;
+  province: string;
+  type: PropertyType;
+  totalDocs: number;
+  locales: Record<string, number>;
+}
+
+interface SuggestionRecord {
+  type: 'property' | 'article' | 'location';
+  id: string;
+  slug: string | null;
+  status?: string;
+  propertyType?: PropertyType;
+  locale: string;
+  title: string;
+  normalized: string;
+}
+
+interface SuggestFile {
+  generatedAt: string;
+  items: SuggestionRecord[];
+}
 
 interface IndexSummary {
   generatedAt: string;
   counts: {
     properties: number;
     articles: number;
+    locations: number;
+    suggestions: number;
   };
+  shards: ShardMetadata[];
 }
+
+const SUPPORTED_LOCALES: SupportedLocale[] = ['th', 'en', 'zh'];
 
 export class IndexService {
   static async rebuild() {
-    const [properties, articles] = await Promise.all([
+    const [properties, articles, locations] = await Promise.all([
       prisma.property.findMany({
         where: {
           workflowState: 'PUBLISHED',
@@ -34,59 +93,185 @@ export class IndexService {
         include: {
           i18n: true
         }
-      })
+      }),
+      prisma.location.findMany()
     ]);
 
-    const propertyDocs = properties.flatMap((property: any) =>
-      property.i18n.map((entry: any) => ({
-        id: `${property.id}:${entry.locale}`,
-        entityId: property.id,
-        slug: property.slug,
-        locale: entry.locale,
-        title: entry.title,
-        description: entry.description ?? '',
-        status: property.status,
-        type: property.type,
-        price: property.price,
-        location: property.location?.province ?? '',
-        deposit: property.deposit ?? false
-      }))
+    const generatedAt = new Date().toISOString();
+    const indexDir = path.resolve(env.INDEX_DIR);
+    await ensureDir(indexDir);
+
+    const shardBuckets = new Map<string, ShardBucket>();
+    const suggestions: SuggestionRecord[] = [];
+
+    for (const property of properties) {
+      const province = this.normalizeProvince(property.location?.province);
+      const shardKey = `${province}::${property.type}`;
+      let shard = shardBuckets.get(shardKey);
+      if (!shard) {
+        const fileName = `${this.toFileSlug(province)}-${property.type.toLowerCase()}.json`;
+        shard = {
+          province,
+          type: property.type,
+          fileName,
+          locales: {}
+        };
+        shardBuckets.set(shardKey, shard);
+      }
+
+      for (const entry of property.i18n) {
+        const normalizedLocale = this.normalizeLocale(entry.locale);
+        if (!this.isSupportedLocale(normalizedLocale)) {
+          continue;
+        }
+
+        const locale = normalizedLocale;
+        const locationLabel = this.composeLocationLabel(property.location?.district, province);
+        const doc: PropertyDoc = {
+          id: `${property.id}:${locale}`,
+          entityId: property.id,
+          slug: property.slug,
+          locale,
+          title: entry.title,
+          description: entry.description ?? '',
+          status: property.status,
+          type: property.type,
+          price: property.price,
+          province,
+          location: locationLabel,
+          deposit: property.deposit ?? false
+        };
+
+        let localeBucket = shard.locales[locale];
+        if (!localeBucket) {
+          localeBucket = {
+            docs: [],
+            index: this.createMiniSearch()
+          };
+          shard.locales[locale] = localeBucket;
+        }
+
+        localeBucket.docs.push(doc);
+        localeBucket.index.add(doc);
+
+        suggestions.push({
+          type: 'property',
+          id: property.id,
+          slug: property.slug,
+          status: property.status,
+          propertyType: property.type,
+          locale,
+          title: entry.title,
+          normalized: this.normalizeText(entry.title)
+        });
+      }
+    }
+
+    for (const article of articles) {
+      for (const entry of article.i18n) {
+        const locale = this.normalizeLocale(entry.locale);
+        suggestions.push({
+          type: 'article',
+          id: article.id,
+          slug: article.slug,
+          locale,
+          title: entry.title,
+          normalized: this.normalizeText(entry.title)
+        });
+      }
+    }
+
+    for (const location of locations) {
+      const label = this.composeLocationLabel(location.district, location.province);
+      suggestions.push({
+        type: 'location',
+        id: location.id,
+        slug: null,
+        locale: 'th',
+        title: label,
+        normalized: this.normalizeText(label)
+      });
+    }
+
+    suggestions.sort(
+      (a, b) =>
+        a.normalized.localeCompare(b.normalized, undefined, { sensitivity: 'base' }) ||
+        a.title.localeCompare(b.title)
     );
 
-    const articleDocs = articles.flatMap((article: any) =>
-      article.i18n.map((entry: any) => ({
-        id: `${article.id}:${entry.locale}`,
-        entityId: article.id,
-        slug: article.slug,
-        locale: entry.locale,
-        title: entry.title,
-        body: typeof entry.body === 'string' ? entry.body : JSON.stringify(entry.body)
-      }))
+    const manifest: ShardMetadata[] = [];
+    const keepFiles = new Set<string>();
+
+    const orderedShards = Array.from(shardBuckets.values()).sort(
+      (a, b) =>
+        a.province.localeCompare(b.province, undefined, { sensitivity: 'base' }) ||
+        a.type.localeCompare(b.type)
     );
 
-    const propertyIndex = new MiniSearch({
-      fields: ['title', 'description', 'location'],
-      storeFields: ['entityId', 'slug', 'title', 'locale', 'status', 'type', 'price', 'deposit']
-    });
-    propertyIndex.addAll(propertyDocs);
+    for (const shard of orderedShards) {
+      const localesPayload = Object.entries(shard.locales).reduce<Record<string, { docs: PropertyDoc[]; index: unknown }>>(
+        (acc, [locale, localeBucket]) => {
+          acc[locale] = {
+            docs: localeBucket.docs,
+            index: localeBucket.index.toJSON()
+          };
+          return acc;
+        },
+        {}
+      );
 
-    const articleIndex = new MiniSearch({
-      fields: ['title', 'body'],
-      storeFields: ['entityId', 'slug', 'title', 'locale']
-    });
-    articleIndex.addAll(articleDocs);
+      const totalDocs = Object.values(localesPayload).reduce((sum, localeData) => sum + localeData.docs.length, 0);
+      const localeCounts = Object.fromEntries(
+        Object.entries(localesPayload).map(([locale, data]) => [locale, data.docs.length])
+      );
+
+      if (Object.keys(localesPayload).length === 0) {
+        continue;
+      }
+
+      const payload = {
+        generatedAt,
+        province: shard.province,
+        type: shard.type,
+        locales: localesPayload
+      };
+
+      await this.writeJson(path.join(indexDir, shard.fileName), payload);
+      keepFiles.add(shard.fileName);
+
+      manifest.push({
+        file: shard.fileName,
+        province: shard.province,
+        type: shard.type,
+        totalDocs,
+        locales: localeCounts
+      });
+    }
+
+    const suggestPayload: SuggestFile = {
+      generatedAt,
+      items: suggestions
+    };
+    await this.writeJson(path.join(indexDir, 'suggest.json'), suggestPayload);
+    keepFiles.add('suggest.json');
 
     const summary: IndexSummary = {
-      generatedAt: new Date().toISOString(),
+      generatedAt,
       counts: {
-        properties: propertyDocs.length,
-        articles: articleDocs.length
-      }
+        properties: properties.length,
+        articles: articles.length,
+        locations: locations.length,
+        suggestions: suggestions.length
+      },
+      shards: manifest
     };
+    await this.writeJson(path.join(indexDir, 'summary.json'), summary);
+    keepFiles.add('summary.json');
 
-    await this.writeJson('properties', propertyIndex.toJSON());
-    await this.writeJson('articles', articleIndex.toJSON());
-    await this.writeJson('summary', summary);
+    await this.writeJson(path.join(indexDir, 'manifest.json'), { generatedAt, shards: manifest });
+    keepFiles.add('manifest.json');
+
+    await this.cleanupObsoleteFiles(indexDir, keepFiles);
 
     return summary;
   }
@@ -100,12 +285,66 @@ export class IndexService {
     }
   }
 
-  private static async writeJson(name: string, data: unknown) {
-    const directory = path.resolve(env.INDEX_DIR);
+  private static createMiniSearch() {
+    return new MiniSearch<PropertyDoc>({
+      fields: ['title', 'description', 'province', 'location'],
+      storeFields: ['entityId', 'slug', 'title', 'locale', 'status', 'type', 'price', 'deposit', 'province', 'location']
+    });
+  }
+
+  private static normalizeLocale(locale: string) {
+    return locale.split('-')[0].toLowerCase();
+  }
+
+  private static normalizeProvince(province?: string | null) {
+    const trimmed = province?.trim();
+    return trimmed && trimmed.length > 0 ? trimmed : 'Unknown';
+  }
+
+  private static isSupportedLocale(locale: string): locale is SupportedLocale {
+    return SUPPORTED_LOCALES.includes(locale as SupportedLocale);
+  }
+
+  private static composeLocationLabel(district?: string | null, province?: string | null) {
+    const parts = [district, province].filter(Boolean) as string[];
+    return parts.length > 0 ? parts.join(' - ') : 'Unknown';
+  }
+
+  private static normalizeText(value: string) {
+    return value.normalize('NFKC').trim().toLowerCase();
+  }
+
+  private static toFileSlug(value: string) {
+    const normalized = value.normalize('NFKC').trim().toLowerCase();
+    return (
+      normalized
+        .replace(/[^\p{Letter}\p{Number}]+/gu, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        || 'unknown'
+    );
+  }
+
+  private static async writeJson(targetPath: string, data: unknown) {
+    const directory = path.dirname(targetPath);
     await ensureDir(directory);
-    const tmpPath = path.join(directory, `${name}.json.tmp`);
-    const targetPath = path.join(directory, `${name}.json`);
+    const tmpPath = `${targetPath}.tmp`;
     await fs.writeFile(tmpPath, JSON.stringify(data));
     await fs.rename(tmpPath, targetPath);
+  }
+
+  private static async cleanupObsoleteFiles(directory: string, keepFiles: Set<string>) {
+    const files = await fs.readdir(directory);
+    await Promise.all(
+      files
+        .filter((file) => file.endsWith('.json') && !keepFiles.has(file))
+        .map(async (file) => {
+          try {
+            await fs.unlink(path.join(directory, file));
+          } catch (error) {
+            console.error('Failed to remove obsolete index file', { file, error });
+          }
+        })
+    );
   }
 }

--- a/src/modules/suggest/routes.ts
+++ b/src/modules/suggest/routes.ts
@@ -3,7 +3,7 @@ import { suggestQuerySchema } from './schemas';
 import { SuggestService } from './service';
 
 export async function registerSuggestRoutes(app: FastifyInstance) {
-  app.get('/v1/suggest', async (request) => {
+  app.get('/api/suggest', async (request) => {
     const query = suggestQuerySchema.parse(request.query);
     const suggestions = await SuggestService.search(query.q);
     return { suggestions };

--- a/src/modules/suggest/service.ts
+++ b/src/modules/suggest/service.ts
@@ -1,96 +1,89 @@
-import { prisma } from '../../prisma/client';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { env } from '../../env';
+
+interface SuggestionRecord {
+  type: 'property' | 'article' | 'location';
+  id: string;
+  slug: string | null;
+  status?: string;
+  propertyType?: string;
+  locale: string;
+  title: string;
+  normalized: string;
+}
+
+interface SuggestFile {
+  generatedAt: string;
+  items: SuggestionRecord[];
+}
+
+interface SuggestCache {
+  mtimeMs: number;
+  data: SuggestFile;
+}
 
 export class SuggestService {
+  private static cache: SuggestCache | null = null;
+
   static async search(query: string) {
-    const normalized = query.trim();
-    if (!normalized) {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
       return [];
     }
 
-    const [propertyTitles, articleTitles, locations] = await Promise.all([
-      prisma.propertyI18N.findMany({
-        where: {
-          title: {
-            startsWith: normalized
-          },
-          property: {
-            is: {
-              workflowState: 'PUBLISHED',
-              deletedAt: null
-            }
-          }
-        },
-        include: {
-          property: {
-            select: {
-              id: true,
-              slug: true,
-              status: true,
-              type: true
-            }
-          }
-        },
-        take: 6
-      }),
-      prisma.articleI18N.findMany({
-        where: {
-          title: {
-            startsWith: normalized
-          },
-          article: {
-            is: {
-              workflowState: 'PUBLISHED',
-              deletedAt: null
-            }
-          }
-        },
-        include: {
-          article: {
-            select: {
-              id: true,
-              slug: true
-            }
-          }
-        },
-        take: 3
-      }),
-      prisma.location.findMany({
-        where: {
-          province: {
-            startsWith: normalized
-          }
-        },
-        take: 3
-      })
-    ]);
+    const data = await this.loadData();
+    const matches = data.items
+      .filter((item) => item.normalized.startsWith(normalizedQuery))
+      .slice(0, 10)
+      .map(({ normalized, ...rest }) => rest);
 
-    const suggestions = [
-      ...propertyTitles.map((item: any) => ({
-        type: 'property',
-        id: item.property.id,
-        slug: item.property.slug,
-        status: item.property.status,
-        propertyType: item.property.type,
-        locale: item.locale,
-        title: item.title
-      })),
-      ...articleTitles
-        .map((item: any) => ({
-          type: 'article',
-          id: item.article.id,
-          slug: item.article.slug,
+    return matches;
+  }
+
+  private static async loadData(): Promise<SuggestFile> {
+    const filePath = path.resolve(env.INDEX_DIR, 'suggest.json');
+    try {
+      const stat = await fs.stat(filePath);
+      if (this.cache && this.cache.mtimeMs === stat.mtimeMs) {
+        return this.cache.data;
+      }
+
+      const raw = await fs.readFile(filePath, 'utf-8');
+      const parsed = JSON.parse(raw) as Partial<SuggestFile>;
+      const items = Array.isArray(parsed.items) ? parsed.items : [];
+      const normalizedItems: SuggestionRecord[] = items.map((item: any) => {
+        const title = typeof item.title === 'string' ? item.title : String(item.title ?? '');
+        return {
+          type: item.type,
+          id: item.id,
+          slug: item.slug ?? null,
+          status: item.status,
+          propertyType: item.propertyType,
           locale: item.locale,
-          title: item.title
-        })),
-      ...locations.map((location: any) => ({
-        type: 'location',
-        id: location.id,
-        slug: null,
-        locale: 'th',
-        title: `${location.province}${location.district ? ' - ' + location.district : ''}`
-      }))
-    ];
+          title,
+          normalized: typeof item.normalized === 'string' ? item.normalized : this.normalizeText(title)
+        };
+      });
 
-    return suggestions.slice(0, 10);
+      const data: SuggestFile = {
+        generatedAt: typeof parsed.generatedAt === 'string' ? parsed.generatedAt : new Date(stat.mtimeMs).toISOString(),
+        items: normalizedItems
+      };
+
+      this.cache = { mtimeMs: stat.mtimeMs, data };
+      return data;
+    } catch (error: any) {
+      if (error?.code === 'ENOENT') {
+        const empty: SuggestFile = { generatedAt: new Date(0).toISOString(), items: [] };
+        this.cache = { mtimeMs: 0, data: empty };
+        return empty;
+      }
+      throw error;
+    }
+  }
+
+  private static normalizeText(value: string) {
+    return value.normalize('NFKC').trim().toLowerCase();
   }
 }


### PR DESCRIPTION
## Summary
- redesign the index rebuild to emit localized property shards with a manifest and global suggestion payload
- load suggestion responses from the prebuilt data and expose them via the new /api/suggest route
- update the public API documentation to point at the new suggest endpoint

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc0d8c5884832b884d72be9c0f34ee