### PR TITLE
docs: update runbook and v6 api overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,46 +29,30 @@ cp .env.example .env
 # Update .env with real credentials and secrets
 ```
 
-### Database setup
+### Developer runbook
 
-Run migrations and seed sample content (admin user `admin`/`ChangeMe123!`, update after first login):
+1. **Boot MySQL** – run `docker compose up -d db` (or point `DATABASE_URL` to your own MySQL 8 instance). When developing migrations locally, also create an empty shadow database and expose it through `SHADOW_DATABASE_URL`.
+2. **Apply migrations** – when pulling an existing branch, execute `npm run migrate` to run `prisma migrate deploy` against the main database. When authoring new schema changes, use `npx prisma migrate dev --name <change>` which consumes both `DATABASE_URL` and `SHADOW_DATABASE_URL`.
+3. **Seed demo content** – `npm run seed` applies migrations and inserts the v6 fixtures (admin user `admin`/`ChangeMe123!`, 50 properties, 5 articles, base FX rate). The script is idempotent and safe to rerun.
+4. **Start the API server** – `npm run dev` launches Fastify via `ts-node-dev` with auto-reload. For a production-like run, build once with `npm run build` and serve using `npm run start`.
 
-```bash
-npm run seed
-```
+### Dev (shadow) vs Prod (deploy)
 
-The seed script executes `prisma migrate deploy` before inserting data.
-
-### Development
-
-```bash
-npm run dev
-```
-
-The dev server uses `ts-node-dev` with automatic reloads.
-
-### Build & production start
-
-```bash
-npm run build
-npm run start
-```
-
-### Prisma utilities
-
-```bash
-npm run migrate      # prisma migrate deploy
-npm run seed         # migrate + seed demo data
-```
+- **Local development** – use `prisma migrate dev` to create new migrations or iterate on schema changes. Prisma requires a shadow database for this workflow; supply it via `SHADOW_DATABASE_URL` (for example a secondary schema on your local MySQL). The command resets the shadow database on every run, so never point it at a shared environment.
+- **Deployed environments** – only run `prisma migrate deploy` (surfaced through `npm run migrate` and inside the seeding script) against staging/production. This command executes already-checked-in migrations without needing a shadow database and is safe for zero-downtime deploys.
 
 ## Environment variables
 
 | Variable | Description |
 | --- | --- |
-| `DATABASE_URL` | MySQL connection string (`mysql://USER:PASS@HOST:3306/DB?sslmode=prefer`) |
+| `DATABASE_URL` | MySQL connection string (`mysql://USER:PASS@HOST:3306/DB`) |
+| `SHADOW_DATABASE_URL` | Optional MySQL URL used only by `prisma migrate dev` when generating migrations |
 | `JWT_SECRET` | 32+ character secret for signing JWT access tokens |
+| `ADMIN_FALLBACK_USERNAME` | Optional emergency admin username accepted only when no users exist |
+| `ADMIN_FALLBACK_PASSWORD` | Optional emergency admin password paired with the fallback username |
 | `CORS_ORIGIN` | Comma-delimited origin allow list (production must include `https://www.zomzomproperty.com`) |
-| `PORT` | HTTP port (default `3001`) |
+| `HOST` | Interface Fastify binds to (default `0.0.0.0`) |
+| `PORT` | HTTP port (default `4000`) |
 | `UPLOAD_DIR` | Filesystem path to store processed uploads (`./public/uploads`) |
 | `WATERMARK_ENABLED` | Toggle watermark overlay for Sharp-processed images (`true`/`false`) |
 | `WATERMARK_TEXT` | Text rendered in the image watermark |
@@ -76,35 +60,58 @@ npm run seed         # migrate + seed demo data
 | `RATE_LIMIT_WINDOW` | Rate limit window in seconds (default `900`, i.e. 15 minutes) |
 | `INDEX_DIR` | Directory for MiniSearch index JSON files (`./public/data/index`) |
 
-## API overview
+## API overview (v6)
 
-All routes are prefixed with `/v1`. Mutation endpoints require JWT Bearer authentication (`Authorization: Bearer <token>`), and additional role checks (`ADMIN`, `EDITOR`, `AGENT`, `USER`).
+All application routes are prefixed with `/v1`; public utilities live under `/api`. Mutating endpoints require JWT Bearer authentication and role-based guards (`ADMIN`, `EDITOR`, `AGENT`, `USER`). Every write audited via `AuditLog`.
 
-- `POST /v1/auth/login` – Obtain access token
-- `GET /v1/auth/me` – Current user profile
-- `POST /v1/properties` – Create property (ADMIN/EDITOR)
-- `PATCH /v1/properties/:id` – Update property (ADMIN/EDITOR)
-- `POST /v1/properties/:id/images` – Upload watermarked images (ADMIN/EDITOR)
-- `DELETE /v1/properties/:id/images/:imageId` – Remove image (ADMIN/EDITOR)
-- `GET /v1/properties` – Filterable, paginated list
-- `GET /v1/properties/:id` – Property detail
-- `POST /v1/articles` / `PATCH /v1/articles/:id` – Manage articles (ADMIN/EDITOR)
-- `GET /v1/articles/:slug` – Public article view (published only)
-- `POST /v1/schedule` – Queue change set (ADMIN)
-- `GET /v1/schedule/jobs` – List publish jobs (ADMIN)
-- `POST /v1/index/rebuild` – Force index rebuild (ADMIN)
-- `GET /api/admin/backup` – Stream ZIP backup (ADMIN)
-- `GET /api/suggest?q=` – Lightweight suggestion service sourced from prebuilt data
+### Health & auth
 
-All mutating operations emit audit log entries.
+- `GET /health` – Liveness probe.
+- `POST /v1/auth/login` – Issues JWT + refreshless session metadata, returns a one-time CSRF token and sets the `csrfToken` cookie (rate-limited to 5 attempts/15 min per IP).
+- `GET /v1/auth/me` – Current user profile.
+- `POST /v1/auth/logout` – Clears the CSRF cookie (requires authentication).
+
+### Properties
+
+- `GET /v1/properties` – Filterable list, honours `x-preview-mode: true` for admins/editors to inspect drafts.
+- `GET /v1/properties/:id` – Property detail with preview support.
+- `POST /v1/properties` – Create property (`ADMIN`/`EDITOR`, CSRF protected).
+- `PATCH /v1/properties/:id` – Update property (`ADMIN`/`EDITOR`, CSRF protected).
+- `POST /v1/properties/:id/images` – Upload images processed via Sharp (`ADMIN`/`EDITOR`, multipart + CSRF protected).
+- `DELETE /v1/properties/:id/images/:imageId` – Remove image (`ADMIN`/`EDITOR`, CSRF protected).
+- `POST /v1/admin/properties/:id/{draft|review|schedule|publish|hide}` – Workflow transitions with audit logging (`ADMIN`/`EDITOR`, CSRF protected; `schedule` accepts `scheduledAt`).
+- `DELETE /v1/admin/properties/:id` – Soft-delete (`ADMIN`/`EDITOR`, CSRF protected).
+- `POST /v1/admin/properties/:id/restore` – Restore a soft-deleted record (`ADMIN`/`EDITOR`, CSRF protected).
+
+### Articles
+
+- `GET /v1/articles/:slug` – Public article view (preview header reveals drafts to editors/admins).
+- `POST /v1/articles` – Create article (`ADMIN`/`EDITOR`, CSRF protected).
+- `PATCH /v1/articles/:id` – Update article (`ADMIN`/`EDITOR`, CSRF protected).
+- `POST /v1/admin/articles/:id/{draft|review|schedule|publish|hide}` – Workflow transitions mirroring properties.
+- `DELETE /v1/admin/articles/:id` – Soft-delete.
+- `POST /v1/admin/articles/:id/restore` – Restore.
+
+### Scheduling & automation
+
+- `POST /v1/schedule` – Queue a change set for the background scheduler (`ADMIN`, CSRF protected).
+- `GET /v1/schedule/jobs` – Inspect queued and historical publish jobs (`ADMIN`).
+- `POST /v1/index/rebuild` – Rebuild MiniSearch index and emit an audit record (`ADMIN`, CSRF protected).
+
+### Operational utilities
+
+- `GET /api/admin/backup` – Streamed ZIP backup with JSON exports and recent uploads (`ADMIN`).
+- `GET /api/suggest?q=` – Lightweight suggestion service sourced from the on-disk search index.
 
 ## File uploads
 
 `POST /v1/properties/:id/images` accepts multipart form data (handled via Formidable). Files are processed through Sharp with optional watermark overlay before being written under `UPLOAD_DIR/properties/<propertyId>/`. The response returns persisted image metadata and URLs.
 
+All state-changing routes require the `x-csrf-token` header to match the `csrfToken` cookie issued at login. The same token must be echoed in the header when calling `POST`, `PATCH`, or `DELETE` endpoints.
+
 ## Scheduling & publishing
 
-`POST /v1/schedule` stores a `ChangeSet` and `PublishJob`. The scheduler (in-process `setInterval` loop) polls every 60 seconds for `queued` jobs whose `runAt` is in the past, applies the patch (property/article update), logs success/failure, and triggers a MiniSearch index rebuild.
+`POST /v1/schedule` stores a `ChangeSet` and `PublishJob`. The scheduler (in-process `setInterval` loop) polls every 60 seconds for `queued` jobs whose `runAt` is in the past, applies the patch (property/article update), logs success/failure, and triggers a MiniSearch index rebuild. Draft content can be previewed by authenticated editors/admins by supplying `x-preview-mode: true` on the relevant GET endpoints.
 
 ## Backups
 


### PR DESCRIPTION
## Summary
- add a developer runbook with migration, seed, and server start steps
- clarify when to use prisma migrate dev with a shadow database versus prisma migrate deploy
- refresh the API overview, environment variables, and operational notes for the v6 endpoints

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cc131d0d68832b9c499c80cd530aaf