### PR TITLE
feat: add shared property filter catalogs

### DIFF
--- a/src/catalog/filters.schema.ts
+++ b/src/catalog/filters.schema.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+import {
+  AMENITIES,
+  FURNITURE_OPTIONS,
+  PRICE_BINS,
+  PROPERTY_STATUS,
+  PROPERTY_TYPES,
+  SECONDARY_TAGS
+} from './filters';
+
+export { AMENITIES, FURNITURE_OPTIONS, PRICE_BINS, PROPERTY_STATUS, PROPERTY_TYPES, SECONDARY_TAGS } from './filters';
+
+type PriceBin = (typeof PRICE_BINS)[number];
+
+export const ZPropertyType = z.enum(PROPERTY_TYPES);
+export const ZPropertyStatus = z.enum(PROPERTY_STATUS);
+export const ZFurniture = z.enum(FURNITURE_OPTIONS);
+export const ZSecondaryTag = z.enum(SECONDARY_TAGS);
+export const ZAmenity = z.enum(AMENITIES);
+export const ZPriceRangeKey = z.enum(PRICE_BINS.map((bin) => bin.key) as [PriceBin['key'], ...PriceBin['key'][]]);
+
+export const ZPropertyFilters = z.object({
+  status: ZPropertyStatus.optional(),
+  type: ZPropertyType.optional(),
+  priceRange: ZPriceRangeKey.optional(),
+  furniture: ZFurniture.optional(),
+  secondaryTags: z.array(ZSecondaryTag).optional(),
+  amenities: z.array(ZAmenity).optional()
+});
+
+export type PropertyFilters = z.infer<typeof ZPropertyFilters>;
+
+export function resolvePriceRange(key: PriceBin['key']) {
+  const bin = PRICE_BINS.find((candidate) => candidate.key === key);
+  if (!bin) return undefined;
+
+  const range: { min: number; max?: number } = { min: bin.min };
+  if ('max' in bin) {
+    range.max = bin.max;
+  }
+  return range;
+}

--- a/src/catalog/filters.ts
+++ b/src/catalog/filters.ts
@@ -1,0 +1,87 @@
+export const PROPERTY_TYPES = [
+  'HOUSE',
+  'TOWNHOME',
+  'COMMERCIAL',
+  'TWINHOUSE',
+  'AFFORDABLE',
+  'FLAT',
+  'CONDO',
+  'ROOM',
+  'LAND',
+  'COURSE',
+  'FORM',
+  'OTHER'
+] as const;
+
+export const PROPERTY_STATUS = ['AVAILABLE', 'RESERVED', 'SOLD'] as const;
+
+export const FURNITURE_OPTIONS = [
+  'FURNISHED',
+  'PARTIALLY_FURNISHED',
+  'UNFURNISHED',
+  'CUSTOM'
+] as const;
+
+export const PRICE_BINS = [
+  { key: 'UNDER_5M', label: 'Under ฿5M', min: 0, max: 5_000_000 },
+  { key: 'FROM_5M_TO_10M', label: '฿5M – ฿10M', min: 5_000_000, max: 10_000_000 },
+  { key: 'FROM_10M_TO_20M', label: '฿10M – ฿20M', min: 10_000_000, max: 20_000_000 },
+  { key: 'FROM_20M_TO_30M', label: '฿20M – ฿30M', min: 20_000_000, max: 30_000_000 },
+  { key: 'FROM_30M_TO_50M', label: '฿30M – ฿50M', min: 30_000_000, max: 50_000_000 },
+  { key: 'ABOVE_50M', label: '฿50M+', min: 50_000_000 }
+] as const;
+
+export const SECONDARY_TAGS = [
+  'NEGOTIABLE',
+  'SPECIAL_PRICE',
+  'NET_PRICE',
+  'MEET_IN_PERSON',
+  'NO_LIEN',
+  'LIENED'
+] as const;
+
+export const AMENITIES = [
+  'backupPower',
+  'beachfront',
+  'butlerSuite',
+  'cafe',
+  'cafeteria',
+  'cinema',
+  'coldStorageReady',
+  'concierge',
+  'coworking',
+  'elevator',
+  'eventSpace',
+  'farmland',
+  'garden',
+  'gym',
+  'heritageFeatures',
+  'highwayFrontage',
+  'homeOffice',
+  'irrigation',
+  'library',
+  'loadingDocks',
+  'marina',
+  'meditationSala',
+  'meetingRooms',
+  'officeWing',
+  'outdoorKitchen',
+  'parking',
+  'playroom',
+  'pool',
+  'riverDeck',
+  'riverfront',
+  'roadAccess',
+  'rooftop',
+  'rooftopFarm',
+  'seaView',
+  'security',
+  'skyDeck',
+  'skyLounge',
+  'smartHome',
+  'solarPanels',
+  'solarReady',
+  'spa',
+  'truckAccess',
+  'utilities'
+] as const;


### PR DESCRIPTION
## Summary
- add catalog constants for property filters to share across the stack
- introduce zod schemas/enums for property filters and utility to resolve price bins

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccde16d7d8832b8b53c77d2ee7922d