### PR TITLE
Use catalog property filters in property listing

### DIFF
--- a/src/catalog/filters.schema.ts
+++ b/src/catalog/filters.schema.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { ZTransitLineId, ZTransitStationId } from './transit';
+
 import {
   AMENITIES,
   FURNITURE_OPTIONS,
@@ -26,7 +28,9 @@ export const ZPropertyFilters = z.object({
   priceRange: ZPriceRangeKey.optional(),
   furniture: ZFurniture.optional(),
   secondaryTags: z.array(ZSecondaryTag).optional(),
-  amenities: z.array(ZAmenity).optional()
+  amenities: z.array(ZAmenity).optional(),
+  nearTransitLine: ZTransitLineId.optional(),
+  nearTransitStation: ZTransitStationId.optional()
 });
 
 export type PropertyFilters = z.infer<typeof ZPropertyFilters>;


### PR DESCRIPTION
## Summary
- extend the catalog property filter schema with transit filter validation
- switch the property listing route to parse queries with the catalog filters and forward pagination separately
- update the property service to accept the new filter type and resolve price ranges

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cce0544344832bb0fc70ccf020ed5b