### PR TITLE
Enhance property catalog filtering and ordering

### DIFF
--- a/src/catalog/filters.schema.ts
+++ b/src/catalog/filters.schema.ts
@@ -22,18 +22,60 @@ export const ZSecondaryTag = z.enum(SECONDARY_TAGS);
 export const ZAmenity = z.enum(AMENITIES);
 export const ZPriceRangeKey = z.enum(PRICE_BINS.map((bin) => bin.key) as [PriceBin['key'], ...PriceBin['key'][]]);
 
-export const ZPropertyFilters = z.object({
+const FURNISHING_FILTERS = ['NONE', 'PARTIAL', 'FULL'] as const;
+
+export const PROPERTY_ORDERING = ['UPDATED_DESC', 'PRICE_ASC', 'PRICE_DESC', 'VIEWS_DESC'] as const;
+
+export const ZFurnishingFilter = z.enum(FURNISHING_FILTERS);
+export const ZPropertyOrdering = z.enum(PROPERTY_ORDERING);
+
+const propertyFilterFields = {
+  q: z.string().trim().min(1).optional(),
   status: ZPropertyStatus.optional(),
   type: ZPropertyType.optional(),
-  priceRange: ZPriceRangeKey.optional(),
-  furniture: ZFurniture.optional(),
-  secondaryTags: z.array(ZSecondaryTag).optional(),
+  priceMin: z.coerce.number().int().nonnegative().optional(),
+  priceMax: z.coerce.number().int().nonnegative().optional(),
+  priceBin: ZPriceRangeKey.optional(),
+  furnished: ZFurnishingFilter.optional(),
+  tags: z.array(ZSecondaryTag).optional(),
   amenities: z.array(ZAmenity).optional(),
   nearTransitLine: ZTransitLineId.optional(),
-  nearTransitStation: ZTransitStationId.optional()
-});
+  nearTransitStation: ZTransitStationId.optional(),
+  orderBy: ZPropertyOrdering.optional()
+} as const;
+
+export const ZPropertyFiltersBase = z.object(propertyFilterFields);
+
+const applyPropertyFilterRefinements = <T extends z.ZodTypeAny>(schema: T) =>
+  schema.superRefine((data, ctx) => {
+    if (data.priceBin !== undefined && (data.priceMin !== undefined || data.priceMax !== undefined)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Cannot combine price bin with explicit min/max',
+        path: ['priceBin']
+      });
+    }
+
+    if (
+      data.priceMin !== undefined &&
+      data.priceMax !== undefined &&
+      data.priceMin > data.priceMax
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'priceMin cannot be greater than priceMax',
+        path: ['priceMin']
+      });
+    }
+  });
+
+export const ZPropertyFilters = applyPropertyFilterRefinements(ZPropertyFiltersBase);
+
+export const withPropertyFilterRefinements = applyPropertyFilterRefinements;
 
 export type PropertyFilters = z.infer<typeof ZPropertyFilters>;
+
+export type PropertyOrdering = z.infer<typeof ZPropertyOrdering>;
 
 export function resolvePriceRange(key: PriceBin['key']) {
   const bin = PRICE_BINS.find((candidate) => candidate.key === key);

--- a/src/modules/properties/routes.ts
+++ b/src/modules/properties/routes.ts
@@ -2,7 +2,11 @@ import { FastifyInstance } from 'fastify';
 import { authenticate, roleGuard } from '../../common/middlewares/authGuard';
 import { verifyCsrfToken } from '../../common/middlewares/csrf';
 import { resolvePreviewMode } from '../../common/utils/preview';
-import { ZPropertyFilters, PropertyFilters } from '../../catalog/filters.schema';
+import {
+  PropertyFilters,
+  ZPropertyFiltersBase,
+  withPropertyFilterRefinements
+} from '../../catalog/filters.schema';
 import { z } from 'zod';
 import { UploadService } from '../uploads/service';
 import { PropertyService } from './service';
@@ -14,10 +18,12 @@ import {
   propertyUpdateSchema
 } from './schemas';
 
-const ZPropertyListQuery = ZPropertyFilters.extend({
-  page: z.coerce.number().int().min(1).default(1),
-  pageSize: z.coerce.number().int().min(1).max(100).default(20)
-});
+const ZPropertyListQuery = withPropertyFilterRefinements(
+  ZPropertyFiltersBase.extend({
+    page: z.coerce.number().int().min(1).default(1),
+    pageSize: z.coerce.number().int().min(1).max(100).default(20)
+  })
+);
 
 export async function registerPropertyRoutes(app: FastifyInstance) {
   app.get('/v1/properties', async (request) => {


### PR DESCRIPTION
## Summary
- extend the property filter schema with search, price bin, furnishing, amenity, tag, transit, and ordering support along with shared refinements
- update `listProperties` to honor the new filters (search, price ranges, furnishing, tags, amenities, transit proximity) and expose the richer ordering options
- ensure property routes parse paginated filter queries using the refined schema helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cce1c917a0832b83e4f0c28d41446a