### PR TITLE
Add catalog filters and transit API endpoints

### DIFF
--- a/src/modules/catalog/routes.ts
+++ b/src/modules/catalog/routes.ts
@@ -1,0 +1,27 @@
+import { FastifyInstance } from 'fastify';
+
+import {
+  AMENITIES,
+  FURNITURE_OPTIONS,
+  PRICE_BINS,
+  PROPERTY_STATUS,
+  PROPERTY_TYPES,
+  SECONDARY_TAGS,
+} from '../../catalog/filters';
+import { TRANSIT_LINES, TRANSIT_STATIONS } from '../../catalog/transit';
+
+export async function registerCatalogRoutes(app: FastifyInstance) {
+  app.get('/api/catalog/filters', async () => ({
+    propertyTypes: PROPERTY_TYPES,
+    propertyStatus: PROPERTY_STATUS,
+    furnitureOptions: FURNITURE_OPTIONS,
+    priceBins: PRICE_BINS,
+    amenities: AMENITIES,
+    secondaryTags: SECONDARY_TAGS,
+  }));
+
+  app.get('/api/catalog/transit', async () => ({
+    lines: TRANSIT_LINES,
+    stations: TRANSIT_STATIONS,
+  }));
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import { registerSchedulerRoutes } from './modules/scheduler/routes';
 import { registerBackupRoutes } from './modules/backup/routes';
 import { registerIndexRoutes } from './modules/index/routes';
 import { registerSuggestRoutes } from './modules/suggest/routes';
+import { registerCatalogRoutes } from './modules/catalog/routes';
 import { SchedulerService } from './modules/scheduler/service';
 
 export async function createServer() {
@@ -66,6 +67,7 @@ export async function createServer() {
   await registerBackupRoutes(app);
   await registerIndexRoutes(app);
   await registerSuggestRoutes(app);
+  await registerCatalogRoutes(app);
 
   // Background scheduler (กันล้มตอนเริ่ม)
   try {


### PR DESCRIPTION
## Summary
- add a catalog routes module exposing filters and transit endpoints
- register the catalog routes during Fastify server setup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cce4652a0c832b96746fd603413722