### PR TITLE
Add light seed script for admin user

### DIFF
--- a/prisma/seed.light.ts
+++ b/prisma/seed.light.ts
@@ -1,0 +1,32 @@
+import 'dotenv/config';
+import bcrypt from 'bcryptjs';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const passwordHash = await bcrypt.hash('admin1234', 10);
+
+  await prisma.user.upsert({
+    where: { username: 'admin' },
+    update: {
+      passwordHash,
+      isActive: true
+    },
+    create: {
+      username: 'admin',
+      passwordHash,
+      isActive: true
+    }
+  });
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (error) => {
+    console.error(error);
+    await prisma.$disconnect();
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- add a lightweight Prisma seed script that provisions an active admin user with an updated default password hash
- ensure the script loads environment variables, hashes the password securely, and disconnects the Prisma client on completion

## Testing
- npx prisma generate
- npm run seed:light *(fails: missing DATABASE_URL in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccfddf3158832bac4b1767844c56da