### PR TITLE
Use app authenticate for auth routes

### DIFF
--- a/src/auth/routes.ts
+++ b/src/auth/routes.ts
@@ -1,6 +1,5 @@
 /// <reference path="../global.d.ts" />
 import type { FastifyPluginAsync } from 'fastify';
-import { authGuard } from '../common/middlewares/authGuard';
 import { clearCsrfCookie, issueCsrfToken } from '../common/middlewares/csrf';
 import { loginSchema } from './schemas';
 import { AuthService } from './service';
@@ -25,12 +24,12 @@ export const registerAuthRoutes: FastifyPluginAsync = async (app) => {
     }
   );
 
-  app.get('/v1/auth/me', { preHandler: [authGuard] }, async (req, reply) => {
+  app.get('/v1/auth/me', { preHandler: [app.authenticate] }, async (req, reply) => {
     if (!req.user) return reply.code(401).send({ error: 'UNAUTHORIZED' });
     return { user: req.user };
   });
 
-  app.post('/v1/auth/logout', { preHandler: [authGuard] }, async (_req, reply) => {
+  app.post('/v1/auth/logout', { preHandler: [app.authenticate] }, async (_req, reply) => {
     reply.clearCookie('token', { path: '/' });
     return { ok: true };
   });


### PR DESCRIPTION
## Summary
- remove the standalone authGuard import from the auth routes
- rely on the Fastify instance's authenticate hook for the me and logout endpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd90bde190832ba016185f82485a1e