### PR TITLE
Update route guards to use app.authenticate

### DIFF
--- a/src/common/middlewares/authGuard.ts
+++ b/src/common/middlewares/authGuard.ts
@@ -1,6 +1,13 @@
 /// <reference path="../../global.d.ts" />
 import type { FastifyReply, FastifyRequest } from 'fastify';
+import jwt from 'jsonwebtoken';
 import type { $Enums } from '@prisma/client';
+
+type UserClaims = {
+  sub: string;
+  username: string;
+  role: $Enums.Role;
+};
 
 export async function authGuard(req: FastifyRequest, reply: FastifyReply) {
   if (!req.user) {
@@ -17,4 +24,32 @@ export function roleGuard(roles: $Enums.Role[]) {
       return reply.code(403).send({ error: 'FORBIDDEN' });
     }
   };
+}
+
+export async function getUserFromRequest(req: FastifyRequest) {
+  if (req.user) {
+    return req.user;
+  }
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const secret = process.env.JWT_SECRET || '';
+  if (!secret) {
+    return null;
+  }
+
+  try {
+    const token = authHeader.slice(7);
+    const decoded = jwt.verify(token, secret) as UserClaims;
+    return {
+      id: decoded.sub,
+      username: decoded.username,
+      role: decoded.role
+    };
+  } catch {
+    return null;
+  }
 }

--- a/src/modules/articles/routes.ts
+++ b/src/modules/articles/routes.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
-import { authenticate, roleGuard } from '../../common/middlewares/authGuard';
+import type { $Enums } from '@prisma/client';
+import { roleGuard } from '../../common/middlewares/authGuard';
 import { verifyCsrfToken } from '../../common/middlewares/csrf';
 import { resolvePreviewMode } from '../../common/utils/preview';
 import {
@@ -21,7 +22,13 @@ export async function registerArticleRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/articles',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request, reply) => {
       const body = articleCreateSchema.parse(request.body);
       const article = await ArticleService.createArticle(body, request.user!.id, {
@@ -34,7 +41,13 @@ export async function registerArticleRoutes(app: FastifyInstance) {
 
   app.patch(
     '/v1/articles/:id',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const params = articleIdParamSchema.parse(request.params);
       const body = articleUpdateSchema.parse(request.body);
@@ -47,7 +60,13 @@ export async function registerArticleRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/admin/articles/:id/draft',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const params = articleIdParamSchema.parse(request.params);
       const article = await ArticleService.transitionState(params.id, 'DRAFT', request.user!.id, {
@@ -59,7 +78,13 @@ export async function registerArticleRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/admin/articles/:id/review',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const params = articleIdParamSchema.parse(request.params);
       const article = await ArticleService.transitionState(params.id, 'REVIEW', request.user!.id, {
@@ -71,7 +96,13 @@ export async function registerArticleRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/admin/articles/:id/schedule',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const params = articleIdParamSchema.parse(request.params);
       const body = articleScheduleTransitionSchema.parse(request.body);
@@ -85,7 +116,13 @@ export async function registerArticleRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/admin/articles/:id/publish',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const params = articleIdParamSchema.parse(request.params);
       const article = await ArticleService.transitionState(params.id, 'PUBLISHED', request.user!.id, {
@@ -97,7 +134,13 @@ export async function registerArticleRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/admin/articles/:id/hide',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const params = articleIdParamSchema.parse(request.params);
       const article = await ArticleService.transitionState(params.id, 'HIDDEN', request.user!.id, {
@@ -109,7 +152,13 @@ export async function registerArticleRoutes(app: FastifyInstance) {
 
   app.delete(
     '/v1/admin/articles/:id',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request, reply) => {
       const params = articleIdParamSchema.parse(request.params);
       await ArticleService.softDelete(params.id, request.user!.id, {
@@ -121,7 +170,13 @@ export async function registerArticleRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/admin/articles/:id/restore',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const params = articleIdParamSchema.parse(request.params);
       const article = await ArticleService.restore(params.id, request.user!.id, {

--- a/src/modules/backup/routes.ts
+++ b/src/modules/backup/routes.ts
@@ -1,11 +1,17 @@
 import { FastifyInstance } from 'fastify';
-import { authenticate, roleGuard } from '../../common/middlewares/authGuard';
+import type { $Enums } from '@prisma/client';
+import { roleGuard } from '../../common/middlewares/authGuard';
 import { BackupService } from './service';
 
 export async function registerBackupRoutes(app: FastifyInstance) {
   app.get(
     '/api/admin/backup',
-    { preHandler: [authenticate, roleGuard(['ADMIN'])] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN'] as $Enums.Role[])
+      ]
+    },
     async (request, reply) => {
       await BackupService.streamBackup(reply, request.user!.id, request.ip);
       return reply;

--- a/src/modules/index/routes.ts
+++ b/src/modules/index/routes.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
-import { authenticate, roleGuard } from '../../common/middlewares/authGuard';
+import type { $Enums } from '@prisma/client';
+import { roleGuard } from '../../common/middlewares/authGuard';
 import { verifyCsrfToken } from '../../common/middlewares/csrf';
 import { createAuditLog } from '../../common/utils/audit';
 import { prisma } from '../../prisma/client';
@@ -8,7 +9,13 @@ import { IndexService } from './service';
 export async function registerIndexRoutes(app: FastifyInstance) {
   app.post(
     '/v1/index/rebuild',
-    { preHandler: [authenticate, roleGuard(['ADMIN']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const summary = await IndexService.rebuild();
       await createAuditLog(prisma, {

--- a/src/modules/properties/routes.ts
+++ b/src/modules/properties/routes.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
-import { authenticate, roleGuard } from '../../common/middlewares/authGuard';
+import type { $Enums } from '@prisma/client';
+import { roleGuard } from '../../common/middlewares/authGuard';
 import { verifyCsrfToken } from '../../common/middlewares/csrf';
 import { resolvePreviewMode } from '../../common/utils/preview';
 import {
@@ -47,7 +48,13 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/properties',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request, reply) => {
       const body = propertyCreateSchema.parse(request.body);
       const property = await PropertyService.createProperty(body, request.user!.id, {
@@ -60,7 +67,13 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
 
   app.patch(
     '/v1/properties/:id',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const params = propertyIdParamSchema.parse(request.params);
       const body = propertyUpdateSchema.parse(request.body);
@@ -73,7 +86,13 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/properties/:id/images',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request, reply) => {
       const params = propertyIdParamSchema.parse(request.params);
       const files = await UploadService.parseImageRequest(request);
@@ -88,7 +107,13 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
 
   app.delete(
     '/v1/properties/:id/images/:imageId',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request, reply) => {
       const params = propertyImageParamSchema.parse(request.params);
       await PropertyService.removeImage(params.id, params.imageId, request.user!.id, {
@@ -100,7 +125,13 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/admin/properties/:id/draft',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const params = propertyIdParamSchema.parse(request.params);
       const property = await PropertyService.transitionState(params.id, 'DRAFT', request.user!.id, {
@@ -112,7 +143,13 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/admin/properties/:id/review',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const params = propertyIdParamSchema.parse(request.params);
       const property = await PropertyService.transitionState(params.id, 'REVIEW', request.user!.id, {
@@ -124,7 +161,13 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/admin/properties/:id/schedule',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const params = propertyIdParamSchema.parse(request.params);
       const body = propertyScheduleTransitionSchema.parse(request.body);
@@ -138,7 +181,13 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/admin/properties/:id/publish',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const params = propertyIdParamSchema.parse(request.params);
       const property = await PropertyService.transitionState(params.id, 'PUBLISHED', request.user!.id, {
@@ -150,7 +199,13 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/admin/properties/:id/hide',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const params = propertyIdParamSchema.parse(request.params);
       const property = await PropertyService.transitionState(params.id, 'HIDDEN', request.user!.id, {
@@ -162,7 +217,13 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
 
   app.delete(
     '/v1/admin/properties/:id',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request, reply) => {
       const params = propertyIdParamSchema.parse(request.params);
       await PropertyService.softDelete(params.id, request.user!.id, {
@@ -174,7 +235,13 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
 
   app.post(
     '/v1/admin/properties/:id/restore',
-    { preHandler: [authenticate, roleGuard(['ADMIN', 'EDITOR']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN', 'EDITOR'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request) => {
       const params = propertyIdParamSchema.parse(request.params);
       const property = await PropertyService.restore(params.id, request.user!.id, {

--- a/src/modules/scheduler/routes.ts
+++ b/src/modules/scheduler/routes.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
-import { authenticate, roleGuard } from '../../common/middlewares/authGuard';
+import type { $Enums } from '@prisma/client';
+import { roleGuard } from '../../common/middlewares/authGuard';
 import { verifyCsrfToken } from '../../common/middlewares/csrf';
 import { scheduleCreateSchema, scheduleJobsQuerySchema } from './schemas';
 import { SchedulerService } from './service';
@@ -7,7 +8,13 @@ import { SchedulerService } from './service';
 export async function registerSchedulerRoutes(app: FastifyInstance) {
   app.post(
     '/v1/schedule',
-    { preHandler: [authenticate, roleGuard(['ADMIN']), verifyCsrfToken] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN'] as $Enums.Role[]),
+        verifyCsrfToken
+      ]
+    },
     async (request, reply) => {
       const body = scheduleCreateSchema.parse(request.body);
       const result = await SchedulerService.createSchedule(body, request.user!.id, request.ip);
@@ -18,7 +25,12 @@ export async function registerSchedulerRoutes(app: FastifyInstance) {
 
   app.get(
     '/v1/schedule/jobs',
-    { preHandler: [authenticate, roleGuard(['ADMIN'])] },
+    {
+      preHandler: [
+        app.authenticate,
+        roleGuard(['ADMIN'] as $Enums.Role[])
+      ]
+    },
     async (request) => {
       const query = scheduleJobsQuerySchema.parse(request.query);
       const jobs = await SchedulerService.listJobs(query.limit, query.status);


### PR DESCRIPTION
## Summary
- update admin route pre-handlers to use the Fastify instance authenticate hook and type-cast literal roles with Prisma enums
- adjust shared auth guard to expose getUserFromRequest for preview mode token decoding

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd91268fb0832ba306ee4a84ac0c90