### PR TITLE
refactor: extract request user helper

### DIFF
--- a/src/common/middlewares/authGuard.ts
+++ b/src/common/middlewares/authGuard.ts
@@ -1,13 +1,6 @@
 /// <reference path="../../global.d.ts" />
 import type { FastifyReply, FastifyRequest } from 'fastify';
-import jwt from 'jsonwebtoken';
 import type { $Enums } from '@prisma/client';
-
-type UserClaims = {
-  sub: string;
-  username: string;
-  role: $Enums.Role;
-};
 
 export async function authGuard(req: FastifyRequest, reply: FastifyReply) {
   if (!req.user) {
@@ -24,32 +17,4 @@ export function roleGuard(roles: $Enums.Role[]) {
       return reply.code(403).send({ error: 'FORBIDDEN' });
     }
   };
-}
-
-export async function getUserFromRequest(req: FastifyRequest) {
-  if (req.user) {
-    return req.user;
-  }
-
-  const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith('Bearer ')) {
-    return null;
-  }
-
-  const secret = process.env.JWT_SECRET || '';
-  if (!secret) {
-    return null;
-  }
-
-  try {
-    const token = authHeader.slice(7);
-    const decoded = jwt.verify(token, secret) as UserClaims;
-    return {
-      id: decoded.sub,
-      username: decoded.username,
-      role: decoded.role
-    };
-  } catch {
-    return null;
-  }
 }

--- a/src/common/utils/preview.ts
+++ b/src/common/utils/preview.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from 'fastify';
 import { httpError } from './httpErrors';
-import { getUserFromRequest } from '../middlewares/authGuard';
+import { getUserFromRequest } from './requestUser';
 
 const PREVIEW_HEADER = 'x-preview-mode';
 

--- a/src/common/utils/requestUser.ts
+++ b/src/common/utils/requestUser.ts
@@ -1,0 +1,37 @@
+import type { FastifyRequest } from 'fastify';
+import jwt from 'jsonwebtoken';
+import type { $Enums } from '@prisma/client';
+
+type UserClaims = {
+  sub: string;
+  username: string;
+  role: $Enums.Role;
+};
+
+export async function getUserFromRequest(req: FastifyRequest) {
+  if (req.user) {
+    return req.user;
+  }
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const secret = process.env.JWT_SECRET || '';
+  if (!secret) {
+    return null;
+  }
+
+  try {
+    const token = authHeader.slice(7);
+    const decoded = jwt.verify(token, secret) as UserClaims;
+    return {
+      id: decoded.sub,
+      username: decoded.username,
+      role: decoded.role
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -7,8 +7,9 @@ declare module 'fastify' {
     user?: {
       id: string;
       username: string;
-      role: $Enums.Role;  // Prisma enum
+      role: $Enums.Role; // Prisma enum
     };
+    previewMode?: boolean;
   }
 
   interface FastifyInstance {


### PR DESCRIPTION
## Summary
- move getUserFromRequest logic into a dedicated common utility
- update authGuard to export only authGuard and roleGuard while importing the helper where needed
- extend Fastify request typings with previewMode to satisfy TypeScript

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd9359e120832bb54c686c9715dfc6