### PR TITLE
Update Zod error handler response format

### DIFF
--- a/src/common/middlewares/errorHandler.ts
+++ b/src/common/middlewares/errorHandler.ts
@@ -4,11 +4,8 @@ import { ZodError } from 'zod';
 export function errorHandler(error: FastifyError, request: FastifyRequest, reply: FastifyReply) {
   if (error instanceof ZodError) {
     reply.status(400).send({
-      message: 'Validation failed',
-      issues: error.errors.map((issue) => ({
-        path: issue.path.join('.'),
-        message: issue.message
-      }))
+      error: 'BAD_REQUEST',
+      issues: error.format()
     });
     return;
   }


### PR DESCRIPTION
## Summary
- return Zod validation errors using the formatted output alongside a BAD_REQUEST code

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdb36f69d8832ba9674346ed5ff87e