### PR TITLE
Add validation schema for index rebuild route

### DIFF
--- a/src/modules/index/routes.ts
+++ b/src/modules/index/routes.ts
@@ -5,10 +5,11 @@ import { verifyCsrfToken } from '../../common/middlewares/csrf';
 import { createAuditLog } from '../../common/utils/audit';
 import { prisma } from '../../prisma/client';
 import { IndexService } from './service';
+import { rebuildRequestSchema, type RebuildBody } from './schemas.autogen';
 import { ensureIdempotencyKey } from '../../common/idempotency';
 
 export async function registerIndexRoutes(app: FastifyInstance) {
-  app.post(
+  app.post<{ Body: RebuildBody }>(
     '/v1/index/rebuild',
     {
       preHandler: [
@@ -18,6 +19,7 @@ export async function registerIndexRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
+      const rebuildRequest = rebuildRequestSchema.parse(request.body);
       const guard = ensureIdempotencyKey(app, 'index.rebuild');
       if (!(await guard(request, reply))) {
         return;
@@ -27,7 +29,7 @@ export async function registerIndexRoutes(app: FastifyInstance) {
         userId: request.user!.id,
         action: 'index.rebuild',
         entityType: 'SearchIndex',
-        meta: summary,
+        meta: { ...summary, request: rebuildRequest },
         ipAddress: request.ip
       });
       return summary;

--- a/src/modules/index/schemas.autogen.ts
+++ b/src/modules/index/schemas.autogen.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const rebuildRequestSchema = z.object({});
+
+export type RebuildBody = z.infer<typeof rebuildRequestSchema>;


### PR DESCRIPTION
## Summary
- add a Zod schema for the index rebuild endpoint payload and export its inferred type
- wire the schema into the rebuild route to leverage Fastify typing and runtime validation
- log the validated request data alongside the rebuild summary to ensure parsing is exercised

## Testing
- `npm run build` *(fails: existing Prisma idemKey type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb629e150832ba2b2160e7dabe5cd