### PR TITLE
Add token version and email verification schema

### DIFF
--- a/prisma/migrations/002_add_email_verification/migration.sql
+++ b/prisma/migrations/002_add_email_verification/migration.sql
@@ -1,0 +1,19 @@
+-- AlterTable
+ALTER TABLE `User` ADD COLUMN `tokenVersion` INTEGER NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE `EmailVerification` (
+    `id` VARCHAR(191) NOT NULL,
+    `userId` VARCHAR(191) NOT NULL,
+    `tokenHash` VARCHAR(191) NOT NULL,
+    `expiresAt` DATETIME(3) NOT NULL,
+    `usedAt` DATETIME(3) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `EmailVerification_tokenHash_key`(`tokenHash`),
+    INDEX `EmailVerification_userId_idx`(`userId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `EmailVerification` ADD CONSTRAINT `EmailVerification_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,11 +61,26 @@ model User {
   role         Role      @default(ADMIN)
   localePref   String?   // admin UI locale
   isActive     Boolean   @default(true)
+  tokenVersion Int       @default(0)
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
   auditLogs    AuditLog[]
   changeSets   ChangeSet[] @relation("ChangeSetCreatedBy")
   favorites    Favorite[]
+  emailVerifications EmailVerification[]
+}
+
+model EmailVerification {
+  id         String   @id @default(cuid())
+  userId     String
+  tokenHash  String
+  expiresAt  DateTime
+  usedAt     DateTime?
+  createdAt  DateTime @default(now())
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@unique([tokenHash])
 }
 
 model Property {

--- a/prisma/seed.light.ts
+++ b/prisma/seed.light.ts
@@ -16,7 +16,8 @@ async function main() {
     create: {
       username: 'admin',
       passwordHash,
-      isActive: true
+      isActive: true,
+      tokenVersion: 0
     }
   });
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1161,7 +1161,8 @@ async function seedAdminUser() {
     create: {
       username: 'admin',
       passwordHash,
-      role: Role.ADMIN
+      role: Role.ADMIN,
+      tokenVersion: 0
     }
   });
 }

--- a/src/auth/service.ts
+++ b/src/auth/service.ts
@@ -46,7 +46,8 @@ export class AuthService {
               username,
               passwordHash,
               role: 'ADMIN',
-              isActive: true
+              isActive: true,
+              tokenVersion: 0
             }
           });
         } else {


### PR DESCRIPTION
## Summary
- add a token version column to users and define the email verification model in the Prisma schema
- create the corresponding Prisma migration and seed defaults for new admin users
- ensure fallback admin creation includes a starting token version

## Testing
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68cdb7715dac832b8e0329c229228948