### PR TITLE
feat(auth): add token utilities

### DIFF
--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -1,0 +1,70 @@
+import type { FastifyReply } from 'fastify';
+import jwt, { type JwtPayload, type SignOptions } from 'jsonwebtoken';
+
+import { env } from '../env';
+
+export const REFRESH_COOKIE_NAME = 'refreshToken';
+
+export type AccessTokenPayload = JwtPayload & {
+  sub: string;
+  [key: string]: unknown;
+};
+
+export type RefreshTokenPayload = JwtPayload & {
+  sub: string;
+  tokenVersion: number;
+};
+
+type ReplyCookieOptions = Parameters<FastifyReply['setCookie']>[2];
+
+const getRefreshCookieOptions = (): ReplyCookieOptions => {
+  const options: ReplyCookieOptions = {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: env.COOKIE_SECURE || env.NODE_ENV === 'production',
+    path: '/',
+  };
+
+  if (typeof env.REFRESH_TOKEN_EXPIRES === 'number') {
+    options.maxAge = env.REFRESH_TOKEN_EXPIRES;
+  }
+
+  if (env.COOKIE_DOMAIN) {
+    options.domain = env.COOKIE_DOMAIN;
+  }
+
+  return options;
+};
+
+const accessTokenExpiresIn = env.ACCESS_TOKEN_EXPIRES as SignOptions['expiresIn'];
+const refreshTokenExpiresIn = env.REFRESH_TOKEN_EXPIRES as SignOptions['expiresIn'];
+
+export function signAccessToken(payload: AccessTokenPayload) {
+  return jwt.sign(payload, env.JWT_SECRET, {
+    expiresIn: accessTokenExpiresIn,
+  });
+}
+
+export function signRefreshToken(payload: RefreshTokenPayload) {
+  return jwt.sign(payload, env.REFRESH_TOKEN_SECRET, {
+    expiresIn: refreshTokenExpiresIn,
+  });
+}
+
+export function setRefreshCookie(reply: FastifyReply, token: string) {
+  reply.setCookie(REFRESH_COOKIE_NAME, token, getRefreshCookieOptions());
+}
+
+export function clearRefreshCookie(reply: FastifyReply) {
+  reply.clearCookie(REFRESH_COOKIE_NAME, getRefreshCookieOptions());
+}
+
+export function verifyRefresh(token: string) {
+  const decoded = jwt.verify(token, env.REFRESH_TOKEN_SECRET);
+
+  if (!decoded || typeof decoded !== 'object') {
+    throw new Error('Invalid refresh token payload');
+  }
+
+  return decoded as RefreshTokenPayload;
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -22,6 +22,11 @@ const envSchema = z.object({
   RATE_LIMIT_MAX: z.coerce.number().int().positive().default(100),
   RATE_LIMIT_WINDOW: z.coerce.number().int().positive().default(15 * 60), // seconds
   INDEX_DIR: z.string().default('./public/data/index'),
+  ACCESS_TOKEN_EXPIRES: z.union([z.coerce.number(), z.string()]).default('15m'),
+  REFRESH_TOKEN_EXPIRES: z.union([z.coerce.number(), z.string()]).default('7d'),
+  REFRESH_TOKEN_SECRET: z.string().min(32, 'REFRESH_TOKEN_SECRET must be at least 32 characters'),
+  COOKIE_SECURE: z.coerce.boolean().default(false),
+  COOKIE_DOMAIN: z.string().optional()
 });
 
 export const env = envSchema.parse(process.env);


### PR DESCRIPTION
## Summary
- extend environment schema with JWT and cookie related settings
- add reusable helpers for issuing and managing access and refresh tokens

## Testing
- npm run build *(fails: existing TypeScript errors in src/auth/service.ts and src/common/idempotency.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb868f73c832b8b22baf1bd9d9f11