### PR TITLE
feat: extend auth persistence and idempotency

### DIFF
--- a/prisma/migrations/003_update_auth_schema/migration.sql
+++ b/prisma/migrations/003_update_auth_schema/migration.sql
@@ -1,0 +1,52 @@
+-- AlterTable
+ALTER TABLE `User`
+    ADD COLUMN `email` VARCHAR(191) NULL,
+    ADD COLUMN `emailVerifiedAt` DATETIME(3) NULL;
+
+CREATE UNIQUE INDEX `User_email_key` ON `User`(`email`);
+
+-- RenameTable
+RENAME TABLE `EmailVerification` TO `VerificationToken`;
+
+-- AlterTable (VerificationToken)
+ALTER TABLE `VerificationToken`
+    DROP FOREIGN KEY `EmailVerification_userId_fkey`;
+
+ALTER TABLE `VerificationToken`
+    MODIFY `userId` VARCHAR(191) NULL,
+    ADD COLUMN `email` VARCHAR(191) NULL;
+
+DROP INDEX `EmailVerification_tokenHash_key` ON `VerificationToken`;
+CREATE UNIQUE INDEX `VerificationToken_tokenHash_key` ON `VerificationToken`(`tokenHash`);
+
+DROP INDEX `EmailVerification_userId_idx` ON `VerificationToken`;
+CREATE INDEX `VerificationToken_userId_idx` ON `VerificationToken`(`userId`);
+CREATE INDEX `VerificationToken_email_idx` ON `VerificationToken`(`email`);
+
+ALTER TABLE `VerificationToken`
+    ADD CONSTRAINT `VerificationToken_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AlterTable (IdemKey)
+ALTER TABLE `IdemKey`
+    ADD COLUMN `bodyHash` VARCHAR(191) NULL,
+    ADD COLUMN `status` INTEGER NULL,
+    ADD COLUMN `responseJson` JSON NULL,
+    ADD COLUMN `responseHash` VARCHAR(191) NULL,
+    ADD COLUMN `expiresAt` DATETIME(3) NULL;
+
+-- CreateTable
+CREATE TABLE `RefreshToken` (
+    `id` VARCHAR(191) NOT NULL,
+    `userId` VARCHAR(191) NOT NULL,
+    `tokenHash` VARCHAR(191) NOT NULL,
+    `expiresAt` DATETIME(3) NULL,
+    `revokedAt` DATETIME(3) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `RefreshToken_tokenHash_key`(`tokenHash`),
+    INDEX `RefreshToken_userId_idx`(`userId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `RefreshToken` ADD CONSTRAINT `RefreshToken_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,7 @@ enum PropertyStatus {
 model User {
   id           String    @id @default(cuid())
   username     String    @unique
+  email        String?   @unique
   passwordHash String
   role         Role      @default(ADMIN)
   localePref   String?   // admin UI locale
@@ -64,22 +65,26 @@ model User {
   tokenVersion Int       @default(0)
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
+  emailVerifiedAt DateTime?
   auditLogs    AuditLog[]
   changeSets   ChangeSet[] @relation("ChangeSetCreatedBy")
   favorites    Favorite[]
-  emailVerifications EmailVerification[]
+  verificationTokens VerificationToken[]
+  refreshTokens      RefreshToken[]
 }
 
-model EmailVerification {
+model VerificationToken {
   id         String   @id @default(cuid())
-  userId     String
+  userId     String?
+  email      String?
   tokenHash  String
   expiresAt  DateTime
   usedAt     DateTime?
   createdAt  DateTime @default(now())
-  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user       User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
+  @@index([email])
   @@unique([tokenHash])
 }
 
@@ -244,15 +249,33 @@ model Favorite {
   @@unique([userId, propertyId])
 }
 
-model IdemKey {
+model IdempotencyKey {
   id        String   @id @default(cuid())
   key       String
   userId    String   @default("__global__")
   route     String
   createdAt DateTime @default(now())
+  bodyHash      String?
+  status        Int?
+  responseJson  Json?
+  responseHash  String?
+  expiresAt     DateTime?
 
+  @@map("IdemKey")
   @@unique([route, key, userId])
   @@index([route, userId])
+}
+
+model RefreshToken {
+  id         String   @id @default(cuid())
+  userId     String
+  tokenHash  String   @unique
+  expiresAt  DateTime?
+  revokedAt  DateTime?
+  createdAt  DateTime @default(now())
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 model ViewStat {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1162,7 +1162,9 @@ async function seedAdminUser() {
       username: 'admin',
       passwordHash,
       role: Role.ADMIN,
-      tokenVersion: 0
+      tokenVersion: 0,
+      email: 'admin@example.com',
+      emailVerifiedAt: new Date()
     }
   });
 }

--- a/src/auth/emailVerification.service.ts
+++ b/src/auth/emailVerification.service.ts
@@ -1,7 +1,7 @@
 import { randomBytes, createHash } from 'crypto';
 import { prisma } from '../prisma/client';
 import { httpError } from '../common/utils/httpErrors';
-import { EmailVerificationRepository } from './emailVerification.repository';
+import { VerificationTokenRepository } from './verificationToken.repository';
 
 const EMAIL_VERIFICATION_TOKEN_BYTES = 32;
 const EMAIL_VERIFICATION_TTL_MS = 60 * 60 * 1000; // 1 hour
@@ -22,8 +22,8 @@ export class EmailVerificationService {
     const expiresAt = new Date(Date.now() + EMAIL_VERIFICATION_TTL_MS);
 
     await prisma.$transaction(async (tx) => {
-      await EmailVerificationRepository.deleteExpiredForUser(userId, new Date(), tx);
-      await EmailVerificationRepository.create({ userId, tokenHash, expiresAt }, tx);
+      await VerificationTokenRepository.deleteExpiredForUser(userId, new Date(), tx);
+      await VerificationTokenRepository.create({ userId, tokenHash, expiresAt }, tx);
     });
 
     return { token, expiresAt };
@@ -31,7 +31,7 @@ export class EmailVerificationService {
 
   static async consumeToken(token: string) {
     const tokenHash = hashToken(token);
-    const verification = await EmailVerificationRepository.findByTokenHash(tokenHash);
+    const verification = await VerificationTokenRepository.findByTokenHash(tokenHash);
 
     if (!verification) {
       throw httpError(400, 'Invalid verification token');
@@ -46,11 +46,15 @@ export class EmailVerificationService {
       throw httpError(400, 'Invalid verification token');
     }
 
+    if (!verification.userId) {
+      throw httpError(400, 'Invalid verification token');
+    }
+
     await prisma.$transaction(async (tx) => {
-      await EmailVerificationRepository.markUsed(verification.id, now, tx);
+      await VerificationTokenRepository.markUsed(verification.id, now, tx);
       await tx.user.update({
         where: { id: verification.userId },
-        data: { isActive: true }
+        data: { isActive: true, emailVerifiedAt: now }
       });
     });
 

--- a/src/auth/routes.ts
+++ b/src/auth/routes.ts
@@ -93,14 +93,14 @@ export const registerAuthRoutes: FastifyPluginAsync = async (app) => {
 
       const user = await prisma.user.findUnique({
         where: { id: request.user.id },
-        select: { id: true, isActive: true }
+        select: { id: true, isActive: true, emailVerifiedAt: true }
       });
 
       if (!user) {
         return reply.code(404).send({ error: 'USER_NOT_FOUND' });
       }
 
-      if (user.isActive) {
+      if (user.emailVerifiedAt || user.isActive) {
         return reply.send({ ok: true, alreadyVerified: true });
       }
 

--- a/src/auth/verificationToken.repository.ts
+++ b/src/auth/verificationToken.repository.ts
@@ -1,4 +1,4 @@
-import type { Prisma, PrismaClient, EmailVerification } from '@prisma/client';
+import type { Prisma, PrismaClient, VerificationToken } from '@prisma/client';
 import { prisma } from '../prisma/client';
 
 type PrismaClientOrTx = PrismaClient | Prisma.TransactionClient;
@@ -7,34 +7,35 @@ type CreateVerificationParams = {
   userId: string;
   tokenHash: string;
   expiresAt: Date;
+  email?: string | null;
 };
 
 const getClient = (client?: PrismaClientOrTx) => client ?? prisma;
 
-export class EmailVerificationRepository {
+export class VerificationTokenRepository {
   static async create(
     data: CreateVerificationParams,
     client?: PrismaClientOrTx
-  ): Promise<EmailVerification> {
+  ): Promise<VerificationToken> {
     const db = getClient(client);
-    return db.emailVerification.create({ data });
+    return db.verificationToken.create({ data });
   }
 
   static async findByTokenHash(
     tokenHash: string,
     client?: PrismaClientOrTx
-  ): Promise<EmailVerification | null> {
+  ): Promise<VerificationToken | null> {
     const db = getClient(client);
-    return db.emailVerification.findUnique({ where: { tokenHash } });
+    return db.verificationToken.findUnique({ where: { tokenHash } });
   }
 
   static async markUsed(
     id: string,
     usedAt: Date,
     client?: PrismaClientOrTx
-  ): Promise<EmailVerification> {
+  ): Promise<VerificationToken> {
     const db = getClient(client);
-    return db.emailVerification.update({ where: { id }, data: { usedAt } });
+    return db.verificationToken.update({ where: { id }, data: { usedAt } });
   }
 
   static async deleteExpiredForUser(
@@ -43,7 +44,7 @@ export class EmailVerificationRepository {
     client?: PrismaClientOrTx
   ): Promise<number> {
     const db = getClient(client);
-    const result = await db.emailVerification.deleteMany({
+    const result = await db.verificationToken.deleteMany({
       where: {
         userId,
         OR: [

--- a/src/common/idempotency.ts
+++ b/src/common/idempotency.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { createHash } from 'crypto';
 import { Prisma } from '@prisma/client';
 import { prisma } from '../prisma/client';
 
@@ -8,6 +9,23 @@ export type IdempotencyGuard = (
   request: FastifyRequest,
   reply: FastifyReply
 ) => Promise<boolean>;
+
+function hashBody(body: unknown): string | null {
+  if (body === null || body === undefined) {
+    return null;
+  }
+
+  if (typeof body === 'string' || Buffer.isBuffer(body)) {
+    return createHash('sha256').update(body).digest('hex');
+  }
+
+  try {
+    const json = JSON.stringify(body);
+    return createHash('sha256').update(json).digest('hex');
+  } catch {
+    return null;
+  }
+}
 
 export function ensureIdempotencyKey(app: FastifyInstance, routeId: string): IdempotencyGuard {
   return async (request, reply) => {
@@ -21,7 +39,7 @@ export function ensureIdempotencyKey(app: FastifyInstance, routeId: string): Ide
     const userScope = request.user?.id ?? ANONYMOUS_SCOPE;
 
     try {
-      const existing = await prisma.idemKey.findUnique({
+      const existing = await prisma.idempotencyKey.findUnique({
         where: {
           route_key_userId: {
             route: routeId,
@@ -33,16 +51,24 @@ export function ensureIdempotencyKey(app: FastifyInstance, routeId: string): Ide
 
       if (existing) {
         if (!reply.sent) {
-          await reply.code(409).send({ error: 'DUPLICATE_REQUEST' });
+          if (existing.status && existing.responseJson) {
+            reply.code(existing.status);
+            await reply.send(existing.responseJson);
+          } else {
+            await reply.code(409).send({ error: 'DUPLICATE_REQUEST' });
+          }
         }
         return false;
       }
 
-      await prisma.idemKey.create({
+      const bodyHash = hashBody(request.body);
+
+      await prisma.idempotencyKey.create({
         data: {
           route: routeId,
           key,
-          userId: userScope
+          userId: userScope,
+          bodyHash
         }
       });
 


### PR DESCRIPTION
## Summary
- add optional email metadata to users and replace EmailVerification with VerificationToken plus RefreshToken and enhanced IdempotencyKey persistence
- update auth services, repository, routes, and seed data to use the new Prisma models and track email verification timestamps
- ensure idempotency guard records request body hashes and can reuse stored responses

## Testing
- npx prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68cec2bb6250832bbb97e7b5d62a49ca