### PR TITLE
Revamp auth flows with refresh token persistence

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -267,15 +267,22 @@ model IdempotencyKey {
 }
 
 model RefreshToken {
-  id         String   @id @default(cuid())
-  userId     String
-  tokenHash  String   @unique
-  expiresAt  DateTime?
-  revokedAt  DateTime?
-  createdAt  DateTime @default(now())
-  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id             String         @id @default(cuid())
+  userId         String
+  tokenHash      String         @unique
+  familyId       String
+  rotatedFromId  String?
+  userAgent      String?
+  ipAddress      String?
+  expiresAt      DateTime?
+  revokedAt      DateTime?
+  createdAt      DateTime       @default(now())
+  user           User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  rotatedFrom    RefreshToken?  @relation("RefreshTokenRotations", fields: [rotatedFromId], references: [id])
+  rotatedChildren RefreshToken[] @relation("RefreshTokenRotations")
 
   @@index([userId])
+  @@index([familyId])
 }
 
 model ViewStat {

--- a/src/auth/emailVerification.service.ts
+++ b/src/auth/emailVerification.service.ts
@@ -51,9 +51,10 @@ export class EmailVerificationService {
     }
 
     await prisma.$transaction(async (tx) => {
+      const userId = verification.userId!;
       await VerificationTokenRepository.markUsed(verification.id, now, tx);
       await tx.user.update({
-        where: { id: verification.userId },
+        where: { id: userId },
         data: { isActive: true, emailVerifiedAt: now }
       });
     });

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -16,7 +16,7 @@ type UserClaims = {
   sub: string;
   username: string;
   role: $Enums.Role; // Prisma enum
-  v?: number;
+  tv: number;
   iat?: number;
   exp?: number;
 };
@@ -50,7 +50,7 @@ const jwtPlugin: FastifyPluginAsync = async (app) => {
       });
 
       if (!user || !user.isActive) throw new Error('User inactive or missing');
-      if (typeof decoded.v === 'number' && user.tokenVersion !== decoded.v) {
+      if (user.tokenVersion !== decoded.tv) {
         throw new Error('Token version mismatch');
       }
 

--- a/src/auth/refreshToken.repository.ts
+++ b/src/auth/refreshToken.repository.ts
@@ -1,0 +1,63 @@
+import type { Prisma, PrismaClient } from '@prisma/client';
+import { prisma } from '../prisma/client';
+
+export type PrismaClientOrTx = PrismaClient | Prisma.TransactionClient;
+
+const getClient = (client?: PrismaClientOrTx) => client ?? prisma;
+
+export type CreateRefreshTokenParams = {
+  id: string;
+  userId: string;
+  tokenHash: string;
+  familyId: string;
+  rotatedFromId?: string | null;
+  userAgent?: string | null;
+  ipAddress?: string | null;
+  expiresAt?: Date | null;
+};
+
+export class RefreshTokenRepository {
+  static async create(data: CreateRefreshTokenParams, client?: PrismaClientOrTx) {
+    const db = getClient(client);
+    return db.refreshToken.create({
+      data: {
+        id: data.id,
+        userId: data.userId,
+        tokenHash: data.tokenHash,
+        familyId: data.familyId,
+        rotatedFromId: data.rotatedFromId ?? null,
+        userAgent: data.userAgent ?? null,
+        ipAddress: data.ipAddress ?? null,
+        expiresAt: data.expiresAt ?? null
+      }
+    });
+  }
+
+  static async findById(id: string, client?: PrismaClientOrTx) {
+    const db = getClient(client);
+    return db.refreshToken.findUnique({ where: { id } });
+  }
+
+  static async findByTokenHash(tokenHash: string, client?: PrismaClientOrTx) {
+    const db = getClient(client);
+    return db.refreshToken.findUnique({ where: { tokenHash } });
+  }
+
+  static async revoke(id: string, revokedAt: Date, client?: PrismaClientOrTx) {
+    const db = getClient(client);
+    return db.refreshToken.update({ where: { id }, data: { revokedAt } });
+  }
+
+  static async revokeFamily(userId: string, familyId: string, revokedAt: Date, client?: PrismaClientOrTx) {
+    const db = getClient(client);
+    await db.refreshToken.updateMany({
+      where: { userId, familyId, revokedAt: null },
+      data: { revokedAt }
+    });
+  }
+
+  static async deleteForUser(userId: string, client?: PrismaClientOrTx) {
+    const db = getClient(client);
+    await db.refreshToken.deleteMany({ where: { userId } });
+  }
+}

--- a/src/auth/refreshToken.service.ts
+++ b/src/auth/refreshToken.service.ts
@@ -1,0 +1,137 @@
+import { prisma } from '../prisma/client';
+import { RefreshTokenRepository } from './refreshToken.repository';
+import {
+  generateTokenId,
+  hashToken,
+  signRefreshToken,
+  type RefreshTokenPayload
+} from './token';
+
+const now = () => new Date();
+
+export class RefreshTokenService {
+  static async issueForLogin(params: {
+    userId: string;
+    tokenVersion: number;
+    userAgent?: string | null;
+    ipAddress?: string | null;
+  }) {
+    const tokenId = generateTokenId();
+    const familyId = generateTokenId();
+    const refreshToken = signRefreshToken({
+      sub: params.userId,
+      tid: tokenId,
+      fid: familyId,
+      tv: params.tokenVersion
+    });
+
+    await RefreshTokenRepository.create({
+      id: tokenId,
+      userId: params.userId,
+      tokenHash: hashToken(refreshToken),
+      familyId,
+      userAgent: params.userAgent ?? null,
+      ipAddress: params.ipAddress ?? null
+    });
+
+    return { refreshToken, familyId, tokenId };
+  }
+
+  static async rotate(params: {
+    rawToken: string;
+    payload: RefreshTokenPayload;
+    tokenVersion: number;
+    userAgent?: string | null;
+    ipAddress?: string | null;
+  }) {
+    const tokenRecord = await RefreshTokenRepository.findById(params.payload.tid);
+    const hashed = hashToken(params.rawToken);
+    const timestamp = now();
+
+    if (
+      !tokenRecord ||
+      tokenRecord.userId !== params.payload.sub ||
+      tokenRecord.familyId !== params.payload.fid
+    ) {
+      await RefreshTokenRepository.revokeFamily(
+        params.payload.sub,
+        params.payload.fid,
+        timestamp
+      );
+      throw new Error('Refresh token reuse detected');
+    }
+
+    if (tokenRecord.tokenHash !== hashed || tokenRecord.revokedAt) {
+      await RefreshTokenRepository.revokeFamily(
+        tokenRecord.userId,
+        tokenRecord.familyId,
+        timestamp
+      );
+      throw new Error('Refresh token reuse detected');
+    }
+
+    const newTokenId = generateTokenId();
+    const refreshToken = signRefreshToken({
+      sub: params.payload.sub,
+      tid: newTokenId,
+      fid: tokenRecord.familyId,
+      tv: params.tokenVersion
+    });
+    const refreshTokenHash = hashToken(refreshToken);
+
+    await prisma.$transaction(async (tx) => {
+      await RefreshTokenRepository.revoke(tokenRecord.id, timestamp, tx);
+      await RefreshTokenRepository.create(
+        {
+          id: newTokenId,
+          userId: tokenRecord.userId,
+          tokenHash: refreshTokenHash,
+          familyId: tokenRecord.familyId,
+          rotatedFromId: tokenRecord.id,
+          userAgent: params.userAgent ?? null,
+          ipAddress: params.ipAddress ?? null
+        },
+        tx
+      );
+    });
+
+    return refreshToken;
+  }
+
+  static async revokeActive(params: {
+    rawToken: string;
+    payload: RefreshTokenPayload;
+  }) {
+    const tokenRecord = await RefreshTokenRepository.findById(params.payload.tid);
+    const timestamp = now();
+
+    if (!tokenRecord) {
+      await RefreshTokenRepository.revokeFamily(
+        params.payload.sub,
+        params.payload.fid,
+        timestamp
+      );
+      return;
+    }
+
+    if (tokenRecord.userId !== params.payload.sub || tokenRecord.familyId !== params.payload.fid) {
+      await RefreshTokenRepository.revokeFamily(
+        params.payload.sub,
+        params.payload.fid,
+        timestamp
+      );
+      return;
+    }
+
+    if (tokenRecord.tokenHash !== hashToken(params.rawToken)) {
+      await RefreshTokenRepository.revokeFamily(
+        tokenRecord.userId,
+        tokenRecord.familyId,
+        timestamp
+      );
+      return;
+    }
+
+    await RefreshTokenRepository.revoke(tokenRecord.id, timestamp);
+  }
+}

--- a/src/auth/schemas.ts
+++ b/src/auth/schemas.ts
@@ -1,13 +1,29 @@
 import { z } from 'zod';
 
 export const loginSchema = z.object({
-  username: z.string().min(1),
+  usernameOrEmail: z.string().min(1, 'Username or email is required'),
   password: z.string().min(8)
 });
 
-export const verifyEmailQuerySchema = z.object({
+export const registerSchema = z.object({
+  username: z
+    .string()
+    .min(3)
+    .max(191)
+    .regex(/^[a-zA-Z0-9_.-]+$/, 'Username may only contain letters, numbers, underscores, hyphens, and dots'),
+  email: z.string().email(),
+  password: z.string().min(8)
+});
+
+export const verificationRequestSchema = z.object({
+  email: z.string().email()
+});
+
+export const verificationConfirmSchema = z.object({
   token: z
     .string()
     .min(1, 'Token is required')
     .regex(/^[a-f0-9]{64}$/i, 'Token must be a 64-character hex string')
 });
+
+export const revokeAllSessionsSchema = z.object({}).strict();


### PR DESCRIPTION
## Summary
- add registration, verification, and revoke-all auth endpoints with updated login payloads
- persist hashed refresh tokens with rotation, reuse detection, and JWT token-version validation
- update Prisma schema for refresh token metadata and log verification links while confirming email activation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cec48871ec832ba879a3201e4f3e84