### PR TITLE
Implement global idempotency middleware

### DIFF
--- a/prisma/migrations/004_update_idem_key_table/migration.sql
+++ b/prisma/migrations/004_update_idem_key_table/migration.sql
@@ -1,0 +1,32 @@
+-- Drop obsolete indexes
+DROP INDEX `IdemKey_route_key_userId_key` ON `IdemKey`;
+DROP INDEX `IdemKey_route_userId_idx` ON `IdemKey`;
+
+-- Extend schema for new idempotency tracking
+ALTER TABLE `IdemKey`
+  ADD COLUMN `method` VARCHAR(16) NULL,
+  ADD COLUMN `path` VARCHAR(191) NULL,
+  ADD COLUMN `requestBody` JSON NULL,
+  ADD COLUMN `requestBodyHash` VARCHAR(191) NULL,
+  ADD COLUMN `status` INTEGER NULL,
+  ADD COLUMN `responseJson` JSON NULL,
+  ADD COLUMN `responseHash` VARCHAR(191) NULL,
+  ADD COLUMN `expiresAt` DATETIME(3) NULL,
+  ADD COLUMN `ipAddress` VARCHAR(191) NULL,
+  ADD COLUMN `userAgent` VARCHAR(191) NULL,
+  MODIFY `userId` VARCHAR(191) NULL;
+
+-- Backfill new required fields
+UPDATE `IdemKey` SET `method` = COALESCE(`method`, 'POST');
+UPDATE `IdemKey` SET `path` = COALESCE(`path`, `route`, '/');
+UPDATE `IdemKey` SET `expiresAt` = COALESCE(`expiresAt`, DATE_ADD(`createdAt`, INTERVAL 1 DAY));
+
+-- Enforce not-null constraints and drop deprecated columns
+ALTER TABLE `IdemKey`
+  MODIFY `method` VARCHAR(16) NOT NULL,
+  MODIFY `path` VARCHAR(191) NOT NULL,
+  DROP COLUMN `route`;
+
+-- Create new indexes
+CREATE UNIQUE INDEX `IdemKey_key_method_path_key` ON `IdemKey`(`key`, `method`, `path`);
+CREATE INDEX `IdemKey_expiresAt_idx` ON `IdemKey`(`expiresAt`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -250,20 +250,24 @@ model Favorite {
 }
 
 model IdempotencyKey {
-  id        String   @id @default(cuid())
-  key       String
-  userId    String   @default("__global__")
-  route     String
-  createdAt DateTime @default(now())
-  bodyHash      String?
-  status        Int?
-  responseJson  Json?
-  responseHash  String?
-  expiresAt     DateTime?
+  id              String   @id @default(cuid())
+  key             String
+  method          String
+  path            String
+  requestBody     Json?
+  requestBodyHash String?
+  status          Int?
+  responseJson    Json?
+  responseHash    String?
+  expiresAt       DateTime?
+  createdAt       DateTime @default(now())
+  userId          String?
+  ipAddress       String?
+  userAgent       String?
 
   @@map("IdemKey")
-  @@unique([route, key, userId])
-  @@index([route, userId])
+  @@unique([key, method, path])
+  @@index([expiresAt])
 }
 
 model RefreshToken {

--- a/src/auth/routes.ts
+++ b/src/auth/routes.ts
@@ -19,18 +19,12 @@ import {
   signAccessToken,
   verifyRefresh
 } from './token';
-import { ensureIdempotencyKey } from '../common/idempotency';
 import { prisma } from '../prisma/client';
 
 export const registerAuthRoutes: FastifyPluginAsync = async (app) => {
   app.post(
     '/v1/auth/register',
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'auth.register');
-      if (!(await guard(request, reply))) {
-        return;
-      }
-
       const body = registerSchema.parse(request.body);
 
       const user = await AuthService.register(body);
@@ -65,10 +59,6 @@ export const registerAuthRoutes: FastifyPluginAsync = async (app) => {
       }
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'auth.login');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const body = loginSchema.parse(request.body);
       const userAgent = request.headers['user-agent'] ?? null;
       const user = await AuthService.login(body.usernameOrEmail, body.password, request.ip);
@@ -98,10 +88,6 @@ export const registerAuthRoutes: FastifyPluginAsync = async (app) => {
   });
 
   app.post('/v1/auth/logout', { preHandler: [app.authenticate] }, async (request, reply) => {
-    const guard = ensureIdempotencyKey(app, 'auth.logout');
-    if (!(await guard(request, reply))) {
-      return;
-    }
     if (!request.user) {
       return reply.code(401).send({ error: 'UNAUTHORIZED' });
     }
@@ -239,11 +225,6 @@ export const registerAuthRoutes: FastifyPluginAsync = async (app) => {
     '/v1/auth/revoke-all',
     { preHandler: [app.authenticate] },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'auth.revoke-all');
-      if (!(await guard(request, reply))) {
-        return;
-      }
-
       if (!request.user) {
         return reply.code(401).send({ error: 'UNAUTHORIZED' });
       }

--- a/src/common/idempotency.ts
+++ b/src/common/idempotency.ts
@@ -1,91 +1,341 @@
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { createHash } from 'crypto';
 import { Prisma } from '@prisma/client';
 import { prisma } from '../prisma/client';
 
-const ANONYMOUS_SCOPE = '__global__';
+const IDEMPOTENT_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const IDEMPOTENCY_HEADER = 'idempotency-key';
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // hourly
 
-export type IdempotencyGuard = (
-  request: FastifyRequest,
-  reply: FastifyReply
-) => Promise<boolean>;
-
-function hashBody(body: unknown): string | null {
-  if (body === null || body === undefined) {
+function canonicalize(value: unknown, seen: WeakSet<object>): unknown {
+  if (value === null) {
     return null;
   }
 
-  if (typeof body === 'string' || Buffer.isBuffer(body)) {
-    return createHash('sha256').update(body).digest('hex');
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== 'object') {
+    if (typeof value === 'bigint') {
+      return value.toString();
+    }
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return value.toString('base64');
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item, seen));
+  }
+
+  if (seen.has(value as object)) {
+    return null;
+  }
+
+  seen.add(value as object);
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, val]) => [key, canonicalize(val, seen)]);
+  seen.delete(value as object);
+  return Object.fromEntries(entries);
+}
+
+function canonicalJson(value: unknown): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  if (value === null) {
+    return 'null';
   }
 
   try {
-    const json = JSON.stringify(body);
-    return createHash('sha256').update(json).digest('hex');
+    const normalized = canonicalize(value, new WeakSet());
+    return JSON.stringify(normalized);
   } catch {
     return null;
   }
 }
 
-export function ensureIdempotencyKey(app: FastifyInstance, routeId: string): IdempotencyGuard {
-  return async (request, reply) => {
-    const headerValue = request.headers['idempotency-key'];
-    const key = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+function hashCanonical(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
 
-    if (!key || typeof key !== 'string') {
-      return true;
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function toJsonInput(
+  value: string | null
+): Prisma.InputJsonValue | typeof Prisma.JsonNull | undefined {
+  if (value === null) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed === null) {
+      return Prisma.JsonNull;
     }
 
-    const userScope = request.user?.id ?? ANONYMOUS_SCOPE;
+    return parsed as Prisma.InputJsonValue;
+  } catch {
+    return undefined;
+  }
+}
+
+function getRequestPath(request: FastifyRequest): string {
+  return (
+    (request.routerPath as string | undefined) ??
+    request.routeOptions?.url ??
+    request.raw.url ??
+    request.url
+  );
+}
+
+async function cleanupExpiredKeys(app: FastifyInstance) {
+  try {
+    const now = new Date();
+    await prisma.idempotencyKey.deleteMany({
+      where: {
+        expiresAt: {
+          lt: now
+        }
+      }
+    });
+  } catch (error) {
+    app.log.error({ err: error }, 'Failed to cleanup expired idempotency keys');
+  }
+}
+
+export function registerIdempotencyMiddleware(app: FastifyInstance): void {
+  let cleanupTimer: NodeJS.Timeout | undefined;
+
+  void cleanupExpiredKeys(app);
+
+  cleanupTimer = setInterval(() => {
+    void cleanupExpiredKeys(app);
+  }, CLEANUP_INTERVAL_MS);
+
+  if (cleanupTimer.unref) {
+    cleanupTimer.unref();
+  }
+
+  app.addHook('onClose', async () => {
+    if (cleanupTimer) {
+      clearInterval(cleanupTimer);
+    }
+  });
+
+  app.addHook('onError', async (request) => {
+    const recordId = request.idempotencyKeyRecordId;
+    if (!recordId) {
+      return;
+    }
 
     try {
-      const existing = await prisma.idempotencyKey.findUnique({
-        where: {
-          route_key_userId: {
-            route: routeId,
-            key,
-            userId: userScope
-          }
-        }
+      await prisma.idempotencyKey.delete({
+        where: { id: recordId }
       });
+    } catch (error) {
+      if (
+        !(error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025')
+      ) {
+        request.log.error(
+          { err: error, idempotencyKeyId: recordId },
+          'Failed to cleanup idempotency key after error'
+        );
+      }
+    }
+  });
 
-      if (existing) {
-        if (!reply.sent) {
-          if (existing.status && existing.responseJson) {
-            reply.code(existing.status);
-            await reply.send(existing.responseJson);
-          } else {
-            await reply.code(409).send({ error: 'DUPLICATE_REQUEST' });
-          }
+  app.addHook('preHandler', async (request, reply) => {
+    const method = request.method.toUpperCase();
+    if (!IDEMPOTENT_METHODS.has(method)) {
+      return;
+    }
+
+    const headerValue = request.headers[IDEMPOTENCY_HEADER];
+    const key = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+
+    if (!key || typeof key !== 'string' || key.trim().length === 0) {
+      return;
+    }
+
+    const normalizedKey = key.trim();
+    const path = getRequestPath(request);
+    const canonicalRequestBody = canonicalJson(request.body);
+    const requestBodyHash = hashCanonical(canonicalRequestBody);
+    const now = new Date();
+
+    let existing = await prisma.idempotencyKey.findUnique({
+      where: {
+        key_method_path: {
+          key: normalizedKey,
+          method,
+          path
         }
-        return false;
+      }
+    });
+
+    if (existing && existing.expiresAt && existing.expiresAt <= now) {
+      try {
+        await prisma.idempotencyKey.delete({ where: { id: existing.id } });
+      } catch (error) {
+        if (
+          !(error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025')
+        ) {
+          request.log.warn(
+            { err: error, idempotencyKeyId: existing.id },
+            'Failed to remove expired idempotency key'
+          );
+        }
+      }
+      existing = null;
+    }
+
+    if (existing) {
+      if ((existing.requestBodyHash ?? null) !== (requestBodyHash ?? null)) {
+        reply.code(409);
+        await reply.send({ error: 'IDEMPOTENCY_KEY_CONFLICT' });
+        return;
       }
 
-      const bodyHash = hashBody(request.body);
+      if (existing.status !== null && existing.status !== undefined) {
+        reply.code(existing.status);
 
-      await prisma.idempotencyKey.create({
+        if (
+          existing.status === 204 ||
+          typeof existing.responseJson === 'undefined'
+        ) {
+          await reply.send();
+        } else {
+          await reply.send(existing.responseJson);
+        }
+      } else {
+        reply.code(409);
+        await reply.send({ error: 'DUPLICATE_REQUEST' });
+      }
+
+      return;
+    }
+
+    let created;
+
+    try {
+      created = await prisma.idempotencyKey.create({
         data: {
-          route: routeId,
-          key,
-          userId: userScope,
-          bodyHash
+          key: normalizedKey,
+          method,
+          path,
+          requestBody: toJsonInput(canonicalRequestBody),
+          requestBodyHash,
+          expiresAt: new Date(Date.now() + IDEMPOTENCY_TTL_MS),
+          userId: request.user?.id ?? null,
+          ipAddress: request.ip,
+          userAgent:
+            typeof request.headers['user-agent'] === 'string'
+              ? request.headers['user-agent']
+              : null
         }
       });
-
-      return true;
     } catch (error) {
       if (
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === 'P2002'
       ) {
-        if (!reply.sent) {
-          await reply.code(409).send({ error: 'DUPLICATE_REQUEST' });
+        const latest = await prisma.idempotencyKey.findUnique({
+          where: {
+            key_method_path: {
+              key: normalizedKey,
+              method,
+              path
+            }
+          }
+        });
+
+        if (latest && (latest.requestBodyHash ?? null) !== (requestBodyHash ?? null)) {
+          reply.code(409);
+          await reply.send({ error: 'IDEMPOTENCY_KEY_CONFLICT' });
+          return;
         }
-        return false;
+
+        if (latest && latest.status !== null && latest.status !== undefined) {
+          reply.code(latest.status);
+          if (
+            latest.status === 204 ||
+            typeof latest.responseJson === 'undefined'
+          ) {
+            await reply.send();
+          } else {
+            await reply.send(latest.responseJson);
+          }
+          return;
+        }
+
+        reply.code(409);
+        await reply.send({ error: 'DUPLICATE_REQUEST' });
+        return;
       }
 
-      app.log.error({ err: error, routeId }, 'Failed to ensure idempotency key');
+      request.log.error({ err: error }, 'Failed to initialize idempotency key');
       throw error;
     }
-  };
+
+    request.idempotencyKeyRecordId = created.id;
+
+    const originalSend = reply.send.bind(reply);
+    let finalized = false;
+
+    reply.send = function patchedSend(payload) {
+      if (!finalized) {
+        finalized = true;
+
+        const statusCode = reply.statusCode;
+
+        void (async () => {
+          try {
+            if (statusCode >= 200 && statusCode < 400) {
+              const canonicalResponse = canonicalJson(payload);
+              const responseJson = toJsonInput(canonicalResponse);
+              const responseHash = hashCanonical(canonicalResponse);
+
+              await prisma.idempotencyKey.update({
+                where: { id: created.id },
+                data: {
+                  status: statusCode,
+                  responseJson,
+                  responseHash,
+                  expiresAt: new Date(Date.now() + IDEMPOTENCY_TTL_MS)
+                }
+              });
+            } else {
+              await prisma.idempotencyKey.delete({ where: { id: created.id } });
+            }
+            request.idempotencyKeyRecordId = undefined;
+          } catch (error) {
+            if (
+              !(error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025')
+            ) {
+              request.log.error(
+                { err: error, idempotencyKeyId: created.id },
+                'Failed to finalize idempotency key'
+              );
+            }
+          }
+        })();
+      }
+
+      return originalSend(payload);
+    };
+  });
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -10,6 +10,7 @@ declare module 'fastify' {
       role: $Enums.Role; // Prisma enum
     };
     previewMode?: boolean;
+    idempotencyKeyRecordId?: string;
   }
 
   interface FastifyInstance {

--- a/src/modules/articles/routes.ts
+++ b/src/modules/articles/routes.ts
@@ -3,7 +3,6 @@ import type { $Enums } from '@prisma/client';
 import { roleGuard } from '../../common/middlewares/authGuard';
 import { verifyCsrfToken } from '../../common/middlewares/csrf';
 import { resolvePreviewMode } from '../../common/utils/preview';
-import { ensureIdempotencyKey } from '../../common/idempotency';
 import {
   articleCreateSchema,
   articleIdParamSchema,
@@ -31,10 +30,6 @@ export async function registerArticleRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'articles.create');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const body = articleCreateSchema.parse(request.body);
       const article = await ArticleService.createArticle(body, request.user!.id, {
         ipAddress: request.ip
@@ -54,10 +49,6 @@ export async function registerArticleRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'articles.update');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = articleIdParamSchema.parse(request.params);
       const body = articleUpdateSchema.parse(request.body);
       const article = await ArticleService.updateArticle(params.id, body, request.user!.id, {
@@ -77,10 +68,6 @@ export async function registerArticleRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'articles.workflow.draft');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = articleIdParamSchema.parse(request.params);
       const article = await ArticleService.transitionState(params.id, 'DRAFT', request.user!.id, {
         ipAddress: request.ip
@@ -99,10 +86,6 @@ export async function registerArticleRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'articles.workflow.review');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = articleIdParamSchema.parse(request.params);
       const article = await ArticleService.transitionState(params.id, 'REVIEW', request.user!.id, {
         ipAddress: request.ip
@@ -121,10 +104,6 @@ export async function registerArticleRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'articles.workflow.schedule');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = articleIdParamSchema.parse(request.params);
       const body = articleScheduleTransitionSchema.parse(request.body);
       const article = await ArticleService.transitionState(params.id, 'SCHEDULED', request.user!.id, {
@@ -145,10 +124,6 @@ export async function registerArticleRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'articles.workflow.publish');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = articleIdParamSchema.parse(request.params);
       const article = await ArticleService.transitionState(params.id, 'PUBLISHED', request.user!.id, {
         ipAddress: request.ip
@@ -167,10 +142,6 @@ export async function registerArticleRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'articles.workflow.hide');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = articleIdParamSchema.parse(request.params);
       const article = await ArticleService.transitionState(params.id, 'HIDDEN', request.user!.id, {
         ipAddress: request.ip
@@ -189,10 +160,6 @@ export async function registerArticleRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'articles.delete');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = articleIdParamSchema.parse(request.params);
       await ArticleService.softDelete(params.id, request.user!.id, {
         ipAddress: request.ip
@@ -211,10 +178,6 @@ export async function registerArticleRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'articles.restore');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = articleIdParamSchema.parse(request.params);
       const article = await ArticleService.restore(params.id, request.user!.id, {
         ipAddress: request.ip

--- a/src/modules/index/routes.ts
+++ b/src/modules/index/routes.ts
@@ -6,7 +6,6 @@ import { createAuditLog } from '../../common/utils/audit';
 import { prisma } from '../../prisma/client';
 import { IndexService } from './service';
 import { rebuildRequestSchema, type RebuildBody } from './schemas.autogen';
-import { ensureIdempotencyKey } from '../../common/idempotency';
 
 export async function registerIndexRoutes(app: FastifyInstance) {
   app.post<{ Body: RebuildBody }>(
@@ -20,10 +19,6 @@ export async function registerIndexRoutes(app: FastifyInstance) {
     },
     async (request, reply) => {
       const rebuildRequest = rebuildRequestSchema.parse(request.body);
-      const guard = ensureIdempotencyKey(app, 'index.rebuild');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const summary = await IndexService.rebuild();
       await createAuditLog(prisma, {
         userId: request.user!.id,

--- a/src/modules/properties/routes.ts
+++ b/src/modules/properties/routes.ts
@@ -3,7 +3,6 @@ import type { $Enums } from '@prisma/client';
 import { roleGuard } from '../../common/middlewares/authGuard';
 import { verifyCsrfToken } from '../../common/middlewares/csrf';
 import { resolvePreviewMode } from '../../common/utils/preview';
-import { ensureIdempotencyKey } from '../../common/idempotency';
 import {
   PropertyFilters,
   ZPropertyFiltersBase,
@@ -57,10 +56,6 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'properties.create');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const body = propertyCreateSchema.parse(request.body);
       const property = await PropertyService.createProperty(body, request.user!.id, {
         ipAddress: request.ip
@@ -80,10 +75,6 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'properties.update');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = propertyIdParamSchema.parse(request.params);
       const body = propertyUpdateSchema.parse(request.body);
       const property = await PropertyService.updateProperty(params.id, body, request.user!.id, {
@@ -103,10 +94,6 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'properties.images.add');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = propertyIdParamSchema.parse(request.params);
       const files = await UploadService.parseImageRequest(request);
       const processed = await UploadService.processPropertyImages(params.id, files);
@@ -128,10 +115,6 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'properties.images.remove');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = propertyImageParamSchema.parse(request.params);
       await PropertyService.removeImage(params.id, params.imageId, request.user!.id, {
         ipAddress: request.ip
@@ -150,10 +133,6 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'properties.workflow.draft');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = propertyIdParamSchema.parse(request.params);
       const property = await PropertyService.transitionState(params.id, 'DRAFT', request.user!.id, {
         ipAddress: request.ip
@@ -172,10 +151,6 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'properties.workflow.review');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = propertyIdParamSchema.parse(request.params);
       const property = await PropertyService.transitionState(params.id, 'REVIEW', request.user!.id, {
         ipAddress: request.ip
@@ -194,10 +169,6 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'properties.workflow.schedule');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = propertyIdParamSchema.parse(request.params);
       const body = propertyScheduleTransitionSchema.parse(request.body);
       const property = await PropertyService.transitionState(params.id, 'SCHEDULED', request.user!.id, {
@@ -218,10 +189,6 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'properties.workflow.publish');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = propertyIdParamSchema.parse(request.params);
       const property = await PropertyService.transitionState(params.id, 'PUBLISHED', request.user!.id, {
         ipAddress: request.ip
@@ -240,10 +207,6 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'properties.workflow.hide');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = propertyIdParamSchema.parse(request.params);
       const property = await PropertyService.transitionState(params.id, 'HIDDEN', request.user!.id, {
         ipAddress: request.ip
@@ -262,10 +225,6 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'properties.delete');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = propertyIdParamSchema.parse(request.params);
       await PropertyService.softDelete(params.id, request.user!.id, {
         ipAddress: request.ip
@@ -284,10 +243,6 @@ export async function registerPropertyRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'properties.restore');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const params = propertyIdParamSchema.parse(request.params);
       const property = await PropertyService.restore(params.id, request.user!.id, {
         ipAddress: request.ip

--- a/src/modules/scheduler/routes.ts
+++ b/src/modules/scheduler/routes.ts
@@ -4,7 +4,6 @@ import { roleGuard } from '../../common/middlewares/authGuard';
 import { verifyCsrfToken } from '../../common/middlewares/csrf';
 import { scheduleCreateSchema, scheduleJobsQuerySchema } from './schemas';
 import { SchedulerService } from './service';
-import { ensureIdempotencyKey } from '../../common/idempotency';
 
 export async function registerSchedulerRoutes(app: FastifyInstance) {
   app.post(
@@ -17,10 +16,6 @@ export async function registerSchedulerRoutes(app: FastifyInstance) {
       ]
     },
     async (request, reply) => {
-      const guard = ensureIdempotencyKey(app, 'schedule.create');
-      if (!(await guard(request, reply))) {
-        return;
-      }
       const body = scheduleCreateSchema.parse(request.body);
       const result = await SchedulerService.createSchedule(body, request.user!.id, request.ip);
       reply.code(201);

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import rateLimit from '@fastify/rate-limit';
 import { env } from './env';
 import { prisma } from './prisma/client';
 import { errorHandler } from './common/middlewares/errorHandler';
+import { registerIdempotencyMiddleware } from './common/idempotency';
 
 // plugins/routes
 import jwtPlugin from './auth/jwt';
@@ -55,6 +56,8 @@ async function bootstrap() {
     },
     credentials: true
   });
+
+  registerIdempotencyMiddleware(app);
 
   // global error handler
   app.setErrorHandler(errorHandler);


### PR DESCRIPTION
## Summary
- add a global Fastify idempotency middleware that canonicalizes request bodies, caches successful responses, and prunes expired keys
- register the middleware and remove per-route idempotency guards so handlers rely on the shared cache
- extend the IdempotencyKey schema with method/path metadata and persistence fields, plus a migration to reshape the table

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cec6e537f4832b80db69d25e55f9a4