### PR TITLE
Add API service compose config and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,51 @@
+# Runtime configuration
+NODE_ENV=development
+HOST=0.0.0.0
+PORT=4000
+
+# Database connectivity
+DATABASE_URL=mysql://zomzom:zomzompass@db:3306/zomzom
+# Optional shadow database used only by `prisma migrate dev`
+SHADOW_DATABASE_URL=
+
+# Token settings
+ACCESS_TOKEN_SECRET=please_change_me_access_token_secret_32_chars_min
+ACCESS_TOKEN_EXPIRES_IN=15m
+REFRESH_TOKEN_SECRET=please_change_me_refresh_token_secret_32_chars_min
+REFRESH_TOKEN_EXPIRES_IN=7d
+
+# Refresh cookie attributes
+REFRESH_COOKIE_HTTP_ONLY=true
+REFRESH_COOKIE_SECURE=false
+REFRESH_COOKIE_SAME_SITE=lax
+REFRESH_COOKIE_PATH=/
+# Optional domain for refresh cookies (leave blank for host-only)
+REFRESH_COOKIE_DOMAIN=
+
+# Optional admin fallback credentials (only used when no users exist)
+ADMIN_FALLBACK_USERNAME=admin
+ADMIN_FALLBACK_PASSWORD=admin1234
+
+# Miscellaneous application settings
+CORS_ORIGIN=http://localhost:3000
+APP_BASE_URL=http://localhost:3000
+EMAIL_FROM=no-reply@example.com
+UPLOAD_DIR=./public/uploads
+WATERMARK_ENABLED=true
+WATERMARK_TEXT=Zomzom Property
+RATE_LIMIT_MAX=100
+RATE_LIMIT_WINDOW=900
+INDEX_DIR=./public/data/index
+
+# MySQL service defaults (match docker-compose.yml)
+MYSQL_ROOT_PASSWORD=rootpass
+MYSQL_DATABASE=zomzom
+MYSQL_USER=zomzom
+MYSQL_PASSWORD=zomzompass
+MYSQL_PORT=3307
+# Optional cookie domain override for other services
+COOKIE_DOMAIN=
+
+# Seeder overrides (optional, fallback to hard-coded defaults if empty)
+SEED_ADMIN_USER=
+SEED_ADMIN_PASS=

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cp .env.example .env
 
 ### Developer runbook
 
-1. **Boot MySQL** – run `docker compose up -d db` (or point `DATABASE_URL` to your own MySQL 8 instance). When developing migrations locally, also create an empty shadow database and expose it through `SHADOW_DATABASE_URL`.
+1. **Boot MySQL** – run `docker compose up -d db` (or point `DATABASE_URL` to your own MySQL 8 instance). The compose file loads shared values from `.env` and defaults to `zomzom`/`zomzompass` (user) with `root`/`rootpass` for the root account so the example `DATABASE_URL` works out of the box. When developing migrations locally, also create an empty shadow database and expose it through `SHADOW_DATABASE_URL`.
 2. **Manage migrations** – Choose the workflow that matches your environment:
    - **Local iteration (`prisma migrate dev`)** – When prototyping locally, run `npx prisma migrate dev --name <change>` with both `DATABASE_URL` and an empty `SHADOW_DATABASE_URL`. This flow regenerates your dev database and shadow schema so you can iterate quickly.
    - **Diff + deploy (recommended for Plesk/production)** – Use the helper script `npm run migrate:init` to wrap `prisma migrate diff` and capture SQL migrations under `prisma/migrations/`. Commit the generated folder and apply it in shared environments with `npx prisma migrate deploy` so no shadow database credentials are required.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,45 @@
 version: '3.8'
 services:
+  api:
+    build:
+      context: .
+    image: zomzom-backend:latest
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - ./.env
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-mysql://zomzom:zomzompass@db:3306/zomzom}
+    command: >-
+      sh -c "npx prisma migrate deploy && node dist/server.js"
+    ports:
+      - "${PORT:-4000}:${PORT:-4000}"
+    volumes:
+      - ./public:/app/public
+    restart: unless-stopped
+
   db:
     image: mysql:8
     container_name: zomzom_mysql
     restart: unless-stopped
+    env_file:
+      - ./.env
     environment:
-      MYSQL_ROOT_PASSWORD: rootpass
-      MYSQL_DATABASE: zomzom
-      MYSQL_USER: zomzom
-      MYSQL_PASSWORD: zomzompass
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-rootpass}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-zomzom}
+      MYSQL_USER: ${MYSQL_USER:-zomzom}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-zomzompass}
     ports:
-      - "3307:3306"   # expose local 3307 → container 3306
+      - "${MYSQL_PORT:-3307}:3306"   # expose local ${MYSQL_PORT} → container 3306
     volumes:
       - dbdata:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    # Default MySQL credentials: `zomzom` / `zomzompass` (user), `root` / `rootpass` (root)
+
 volumes:
   dbdata:


### PR DESCRIPTION
## Summary
- add an api service to docker-compose that builds the backend, waits for mysql, and runs migrations before starting
- provide a comprehensive .env.example covering runtime, token, cookie, and mysql defaults shared with compose
- document the docker compose defaults for mysql credentials so the sample DATABASE_URL works immediately

## Testing
- npm run build *(fails: existing TypeScript errors in auth/idempotency modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cec9dd229c832ba64b2d3cea94b868