### PR TITLE
Require auth for verification requests and log full URLs

### DIFF
--- a/src/auth/schemas.ts
+++ b/src/auth/schemas.ts
@@ -15,10 +15,6 @@ export const registerSchema = z.object({
   password: z.string().min(8)
 });
 
-export const verificationRequestSchema = z.object({
-  email: z.string().email()
-});
-
 export const verificationConfirmSchema = z.object({
   token: z
     .string()

--- a/src/env.ts
+++ b/src/env.ts
@@ -36,6 +36,7 @@ const envSchema = z.object({
   ADMIN_FALLBACK_USERNAME: z.string().optional(),
   ADMIN_FALLBACK_PASSWORD: z.string().optional(),
   CORS_ORIGIN: z.string().default('http://localhost:3000'),
+  APP_BASE_URL: z.string().url().default('http://localhost:3000'),
   UPLOAD_DIR: z.string().default('./public/uploads'),
   WATERMARK_ENABLED: z.coerce.boolean().default(true),
   WATERMARK_TEXT: z.string().default('Zomzom Property'),


### PR DESCRIPTION
## Summary
- require authentication for the email verification request endpoint and source the recipient from the session, logging the full verification URL
- include the application base URL when logging verification links issued during registration
- validate the APP_BASE_URL environment variable and remove the unused verification request schema

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cedc876214832bb616460b85a094ce