### PR TITLE
Adjust refresh token reuse response

### DIFF
--- a/src/auth/routes.ts
+++ b/src/auth/routes.ts
@@ -210,7 +210,7 @@ export const registerAuthRoutes: FastifyPluginAsync = async (app) => {
     } catch (error) {
       request.log.warn({ err: error }, 'Refresh token reuse detected, revoking family');
       clearRefreshCookie(reply);
-      return reply.code(403).send({ error: 'FORBIDDEN' });
+      return reply.code(401).send({ error: 'UNAUTHORIZED' });
     }
 
     const accessToken = signAccessToken({


### PR DESCRIPTION
## Summary
- return a 401 UNAUTHORIZED response when refresh token reuse is detected while rotating tokens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cedde80764832b807d777f17ca764a