### PR TITLE
Make refresh cookie configuration env-driven

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ REFRESH_TOKEN_EXPIRES_IN=7d
 REFRESH_COOKIE_HTTP_ONLY=true
 REFRESH_COOKIE_SECURE=false
 REFRESH_COOKIE_SAME_SITE=lax
-REFRESH_COOKIE_PATH=/
+REFRESH_COOKIE_PATH=/v1/auth/refresh
 # Optional domain for refresh cookies (leave blank for host-only)
 REFRESH_COOKIE_DOMAIN=
 

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -28,10 +28,10 @@ type ReplyCookieOptions = Parameters<FastifyReply['setCookie']>[2];
 
 const getRefreshCookieOptions = (): ReplyCookieOptions => {
   const options: ReplyCookieOptions = {
-    httpOnly: true,
-    sameSite: 'lax',
-    secure: env.NODE_ENV === 'production',
-    path: '/v1/auth/refresh'
+    httpOnly: env.REFRESH_COOKIE_HTTP_ONLY,
+    sameSite: env.REFRESH_COOKIE_SAME_SITE,
+    secure: env.REFRESH_COOKIE_SECURE,
+    path: env.REFRESH_COOKIE_PATH
   };
 
   if (env.REFRESH_COOKIE_DOMAIN) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -31,7 +31,7 @@ const envSchema = z.object({
   REFRESH_COOKIE_HTTP_ONLY: z.coerce.boolean().default(true),
   REFRESH_COOKIE_SECURE: z.coerce.boolean().default(false),
   REFRESH_COOKIE_SAME_SITE: sameSiteSchema,
-  REFRESH_COOKIE_PATH: z.string().default('/'),
+  REFRESH_COOKIE_PATH: z.string().default('/v1/auth/refresh'),
   REFRESH_COOKIE_DOMAIN: z.string().optional(),
   ADMIN_FALLBACK_USERNAME: z.string().optional(),
   ADMIN_FALLBACK_PASSWORD: z.string().optional(),


### PR DESCRIPTION
## Summary
- read refresh cookie options from environment configuration instead of hard-coded defaults
- update refresh cookie path default to `/v1/auth/refresh` in runtime schema and example env file

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cede5b6624832ba6d7eb1d239e37b6